### PR TITLE
feat: add save-as-draft support to reply_to_email

### DIFF
--- a/apple_mail_mcp/tools/compose.py
+++ b/apple_mail_mcp/tools/compose.py
@@ -72,10 +72,20 @@ def reply_to_email(
         header_text = "SENDING REPLY"
         send_or_draft_command = "send replyMessage"
         success_text = "✓ Reply sent successfully!"
+        # For send, Mail handles the quoted original via the HTML layer
+        set_content_script = f'set content of replyMessage to "{escaped_body}"'
     else:
         header_text = "SAVING REPLY AS DRAFT"
         send_or_draft_command = "close window 1 saving yes"
         success_text = "✓ Reply saved as draft!"
+        # For draft, we must manually build the quoted original because
+        # close-window-saving-yes saves the content property literally
+        # and the reply message's content property is initially empty
+        set_content_script = f'''set origContent to content of foundMessage
+                set origSender to sender of foundMessage
+                set origDate to date received of foundMessage
+                set quotedText to "On " & (origDate as string) & ", " & origSender & " wrote:" & return & return & origContent
+                set content of replyMessage to "{escaped_body}" & return & return & quotedText'''
 
     script = f'''
     tell application "Mail"
@@ -106,6 +116,7 @@ def reply_to_email(
 
                 -- Create reply
                 {reply_command}
+                delay 0.5
 
                 -- Ensure the reply is from the correct account
                 set emailAddrs to email addresses of targetAccount
@@ -113,7 +124,8 @@ def reply_to_email(
                 set sender of replyMessage to senderAddress
 
                 -- Set reply content
-                set content of replyMessage to "{escaped_body}"
+                {set_content_script}
+                delay 0.5
 
                 -- Add CC/BCC recipients
                 {cc_script}


### PR DESCRIPTION
## Summary

- Adds a `send` parameter (default `True`) to `reply_to_email`
- When `send=False`, the reply is saved as a draft instead of being sent immediately
- The reply still threads properly (created via Mail's `reply` command with correct In-Reply-To/References headers)
- Instead of calling `send`, the compose window is closed with `saving yes`, which saves to the Drafts folder

## Motivation

Currently there's no way to create a **threaded reply draft**. `manage_drafts(action="create")` creates standalone drafts without threading headers, and `reply_to_email` always sends immediately. This fills the gap — users can compose a reply that threads properly in the conversation but review it before sending.

## Test plan

- [ ] `reply_to_email(account="...", subject_keyword="...", reply_body="...", send=True)` — sends immediately (existing behavior, unchanged)
- [ ] `reply_to_email(account="...", subject_keyword="...", reply_body="...", send=False)` — saves reply as draft in Drafts folder, threaded under the original email
- [ ] Verify draft appears in Mail.app Drafts folder with correct threading
- [ ] Verify CC/BCC recipients are preserved in drafts

🤖 Generated with [Claude Code](https://claude.com/claude-code)