### PR TITLE
fix: sanitize AppleScript output to prevent JSON serialization errors

### DIFF
--- a/apple_mail_mcp/__main__.py
+++ b/apple_mail_mcp/__main__.py
@@ -1,0 +1,12 @@
+"""Entry point for `python -m apple_mail_mcp`."""
+
+from apple_mail_mcp.server import mcp
+
+# Import tool modules to register @mcp.tool() decorators
+from apple_mail_mcp.tools import inbox      # noqa: F401
+from apple_mail_mcp.tools import search     # noqa: F401
+from apple_mail_mcp.tools import compose    # noqa: F401
+from apple_mail_mcp.tools import manage     # noqa: F401
+from apple_mail_mcp.tools import analytics  # noqa: F401
+
+mcp.run()

--- a/apple_mail_mcp/core.py
+++ b/apple_mail_mcp/core.py
@@ -24,19 +24,38 @@ def escape_applescript(value: str) -> str:
     return value.replace('\\', '\\\\').replace('"', '\\"')
 
 
+def _sanitize_for_json(text: str) -> str:
+    """Sanitize text for safe JSON serialization over MCP stdio transport.
+
+    Forces ASCII-safe output to avoid encoding issues in the
+    Desktop <-> CLI <-> MCP communication chain.
+    """
+    # Normalize line endings first (AppleScript uses \r)
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
+    # Force ASCII: replaces non-ASCII chars with their Unicode escape or drops them
+    text = text.encode('ascii', 'replace').decode('ascii')
+    # Strip remaining control characters (keep \n and \t)
+    return ''.join(
+        ch for ch in text
+        if ch in ('\n', '\t') or (' ' <= ch <= '~')
+    )
+
+
 def run_applescript(script: str) -> str:
     """Execute AppleScript via stdin pipe for reliable multi-line handling"""
     try:
         result = subprocess.run(
             ['osascript', '-'],
-            input=script,
+            input=script.encode('utf-8'),
             capture_output=True,
-            text=True,
             timeout=120
         )
-        if result.returncode != 0 and result.stderr.strip():
-            raise Exception(f"AppleScript error: {result.stderr.strip()}")
-        return result.stdout.strip()
+        if result.returncode != 0:
+            stderr = result.stderr.decode('utf-8', errors='replace').strip()
+            if stderr:
+                raise Exception(f"AppleScript error: {stderr}")
+        output = result.stdout.decode('utf-8', errors='replace').strip()
+        return _sanitize_for_json(output)
     except subprocess.TimeoutExpired:
         raise Exception("AppleScript execution timed out")
     except Exception as e:


### PR DESCRIPTION
## Summary
- Email content from AppleScript can contain characters (control chars, `\r` line endings, U+FFFC object replacement chars) that break the MCP stdio JSON-RPC transport, causing **"CLI output was not valid JSON"** errors in Claude Desktop
- Adds `_sanitize_for_json()` to normalize line endings, force ASCII-safe output, and strip control characters from all AppleScript results
- Switches `run_applescript()` to bytes mode with explicit UTF-8 decoding (`errors='replace'`) instead of `text=True` which relies on locale encoding
- Adds `__main__.py` entry point to eliminate a `RuntimeWarning` on stderr when running via `python -m apple_mail_mcp` (stderr output corrupts the MCP stdio channel)

## Test plan
- [ ] Call `get_email_with_content` with emails containing HTML content (images, special chars) in Claude Desktop
- [ ] Verify no "CLI output was not valid JSON" errors
- [ ] Verify server starts cleanly with `python -m apple_mail_mcp` (no RuntimeWarning on stderr)
- [ ] Verify other tools (search_emails, list_inbox_emails, etc.) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)