### PR TITLE
feat: add --read-only flag to disable email sending tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ Restart Claude Desktop and grant Mail.app permissions when prompted.
 
 ## Configuration
 
+### Read-Only Mode
+
+Pass `--read-only` to disable tools that send email (`compose_email`, `reply_to_email`, `forward_email`). Draft management remains available (list, create, delete) but sending a draft via `manage_drafts` is blocked.
+
+```json
+{
+  "mcpServers": {
+    "apple-mail": {
+      "command": "/path/to/venv/bin/python3",
+      "args": ["/path/to/apple_mail_mcp.py", "--read-only"]
+    }
+  }
+}
+```
+
 ### User Preferences (Optional)
 
 Set the `USER_EMAIL_PREFERENCES` environment variable to give the assistant context about your workflow:

--- a/apple_mail_mcp.py
+++ b/apple_mail_mcp.py
@@ -1,7 +1,37 @@
 #!/usr/bin/env python3
-"""Apple Mail MCP Server - Entry point (thin wrapper)."""
+"""Apple Mail MCP Server - Entry point.
 
-from apple_mail_mcp import mcp
+Supports --read-only to disable tools that send email (compose, reply, forward).
+Draft management (list, create, delete) remains available; only the draft "send"
+action is blocked.
+"""
+
+import argparse
+import apple_mail_mcp.server as server
+
+parser = argparse.ArgumentParser(description="Apple Mail MCP Server")
+parser.add_argument(
+    "--read-only",
+    action="store_true",
+    help="Disable tools that send email (compose, reply, forward). "
+         "Drafts can still be created and listed.",
+)
+args = parser.parse_args()
+
+# Set the flag before tools are imported (decorator registration happens on import).
+server.READ_ONLY = args.read_only
+
+from apple_mail_mcp import mcp  # noqa: E402
+
+# In read-only mode, remove send-capable tools that were registered by decorators.
+SEND_TOOLS = ["compose_email", "reply_to_email", "forward_email"]
+
+if args.read_only:
+    for name in SEND_TOOLS:
+        try:
+            mcp.remove_tool(name)
+        except (KeyError, ValueError):
+            pass  # Tool may not exist — fine to skip.
 
 if __name__ == "__main__":
     mcp.run()

--- a/apple_mail_mcp/server.py
+++ b/apple_mail_mcp/server.py
@@ -8,3 +8,7 @@ mcp = FastMCP("Apple Mail MCP")
 
 # Load user preferences from environment
 USER_PREFERENCES = os.environ.get("USER_EMAIL_PREFERENCES", "")
+
+# Read-only mode flag — set via --read-only CLI argument.
+# When enabled, tools that send email are disabled. Drafts remain available.
+READ_ONLY = False

--- a/apple_mail_mcp/tools/compose.py
+++ b/apple_mail_mcp/tools/compose.py
@@ -6,7 +6,7 @@ import tempfile
 from typing import Optional, List, Tuple
 
 
-from apple_mail_mcp.server import mcp
+from apple_mail_mcp.server import mcp, READ_ONLY
 from apple_mail_mcp.core import inject_preferences, escape_applescript, run_applescript, inbox_mailbox_script
 
 
@@ -957,6 +957,8 @@ def manage_drafts(
         '''
 
     elif action == "send":
+        if READ_ONLY:
+            return "Error: Sending drafts is disabled in read-only mode."
         if not draft_subject:
             return "Error: 'draft_subject' is required for sending drafts"
 


### PR DESCRIPTION
## Summary

- Adds a `--read-only` CLI flag that removes `compose_email`, `reply_to_email`, and `forward_email` from the MCP tool registry at startup
- Draft management (`list`, `create`, `delete`) remains available but the `send` action on drafts is blocked
- Useful for deployments where you want inbox access without outbound email capability

## Changes

- `apple_mail_mcp.py`: parse `--read-only` arg and pass to server
- `apple_mail_mcp/server.py`: export `READ_ONLY` flag
- `apple_mail_mcp/tools/compose.py`: guard `manage_drafts` send action behind `READ_ONLY`
- `README.md`: document the flag

## Test plan

- [x] Run with `--read-only` flag, verify compose/reply/forward tools are absent
- [x] Run without flag, verify all tools present
- [x] With `--read-only`, verify `manage_drafts` action=send returns error
- [x] With `--read-only`, verify `manage_drafts` list/create/delete still work