### PR TITLE
feat: add rich draft workflow and structured mail search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Apple Mail MCP Server will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`create_rich_email_draft`**: Create multipart rich-text `.eml` drafts, open them in Mail, and optionally save them to Drafts
+
+### Changed
+- Documented `.eml`-based rich draft creation as the preferred workflow for HTML emails in README, skill docs, and agent guidance
+
+### Fixed
+- Clarified the recommended workaround for Mail drafts that show literal HTML instead of rendered rich content
+
 ## [1.6.1] - 2026-03-10
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Restart Claude Desktop and grant Mail.app permissions when prompted.
 
 > **Tip:** An `.mcpb` bundle is also available on the [Releases](https://github.com/patrickfreyer/apple-mail-mcp/releases) page for one-click install in Claude Desktop.
 
-## Tools (26)
+## Tools (27)
 
 ### Reading & Search
 | Tool | Description |
@@ -73,6 +73,7 @@ Restart Claude Desktop and grant Mail.app permissions when prompted.
 | `reply_to_email` | Reply or reply-all with optional CC/BCC |
 | `forward_email` | Forward with optional message, CC/BCC |
 | `manage_drafts` | Create, list, send, and delete drafts |
+| `create_rich_email_draft` | Build a rich HTML `.eml` draft, open it in Mail, and optionally save it to Drafts |
 
 ### Attachments
 | Tool | Description |
@@ -144,7 +145,19 @@ Search for emails about "project update" in my Gmail
 Reply to the email about "Domain name" with "Thanks for the update!"
 Move emails with "invoice" in the subject to my Archive folder
 Show me email statistics for the last 30 days
+Create a rich HTML draft for a weekly update and open it in Mail
 ```
+
+### Rich HTML Drafts
+
+Use `create_rich_email_draft` when you need a visually formatted email, newsletter, or leadership update.
+
+- It generates an unsent `.eml` file with multipart plain-text + HTML bodies
+- It can open the draft directly in Mail for editing
+- It can optionally ask Mail to save the opened compose window into Drafts
+- It accepts partial details, so you can start with just an account and subject and fill in the rest later
+
+This is more reliable than injecting raw HTML into AppleScript `content`, which Mail often stores as literal markup.
 
 ## Email Management Skill
 
@@ -172,12 +185,13 @@ See [skill-email-management/README.md](skill-email-management/README.md) for det
 | Slow searches | Set `include_content: false` and lower `max_results` |
 | Mailbox not found | Use exact folder names; nested folders use `/` separator (e.g., `Projects/Alpha`) |
 | Permission errors | Grant access in **System Settings > Privacy & Security > Automation** |
+| Rich draft shows raw HTML | Use `create_rich_email_draft` instead of pasting HTML into `manage_drafts` or AppleScript `content` |
 
 ## Project Structure
 
 ```
 apple-mail-mcp/
-├── apple_mail_mcp.py          # Main MCP server (26 tools)
+├── apple_mail_mcp.py          # Main MCP server (27 tools)
 ├── requirements.txt           # Python dependencies
 ├── apple-mail-mcpb/           # MCP Bundle build files
 ├── skill-email-management/    # Email Management Expert Skill

--- a/apple_mail_mcp/__init__.py
+++ b/apple_mail_mcp/__init__.py
@@ -5,15 +5,16 @@ from apple_mail_mcp.server import mcp
 # UI availability flag
 try:
     from ui import create_inbox_dashboard_ui
+
     UI_AVAILABLE = True
 except ImportError:
     UI_AVAILABLE = False
 
 # Import all tool modules to register @mcp.tool() decorators
-from apple_mail_mcp.tools import inbox      # noqa: F401  (6 tools)
-from apple_mail_mcp.tools import search     # noqa: F401  (1 tool)
-from apple_mail_mcp.tools import compose    # noqa: F401  (4 tools)
-from apple_mail_mcp.tools import manage     # noqa: F401  (6 tools)
-from apple_mail_mcp.tools import bulk       # noqa: F401  (3 tools)
+from apple_mail_mcp.tools import inbox  # noqa: F401  (6 tools)
+from apple_mail_mcp.tools import search  # noqa: F401  (8 tools)
+from apple_mail_mcp.tools import compose  # noqa: F401  (5 tools)
+from apple_mail_mcp.tools import manage  # noqa: F401  (7 tools)
+from apple_mail_mcp.tools import bulk  # noqa: F401  (3 tools)
 from apple_mail_mcp.tools import analytics  # noqa: F401  (4 tools)
 from apple_mail_mcp.tools import smart_inbox  # noqa: F401  (3 tools)

--- a/apple_mail_mcp/core.py
+++ b/apple_mail_mcp/core.py
@@ -1,7 +1,7 @@
 """Core helpers: AppleScript execution, escaping, parsing, and preference injection."""
 
 import subprocess
-from typing import List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 
 from apple_mail_mcp.server import USER_PREFERENCES
 
@@ -10,7 +10,9 @@ def inject_preferences(func):
     """Decorator that appends user preferences to tool docstrings"""
     if USER_PREFERENCES:
         if func.__doc__:
-            func.__doc__ = func.__doc__.rstrip() + f"\n\nUser Preferences: {USER_PREFERENCES}"
+            func.__doc__ = (
+                func.__doc__.rstrip() + f"\n\nUser Preferences: {USER_PREFERENCES}"
+            )
         else:
             func.__doc__ = f"User Preferences: {USER_PREFERENCES}"
     return func
@@ -24,16 +26,15 @@ def escape_applescript(value: str) -> str:
     syntax errors.
     """
     return (
-        value
-        .replace('\\', '\\\\')
+        value.replace("\\", "\\\\")
         .replace('"', '\\"')
-        .replace('\r\n', '\\n')
-        .replace('\r', '\\n')
-        .replace('\n', '\\n')
-        .replace('\t', '\\t')
+        .replace("\r\n", "\\n")
+        .replace("\r", "\\n")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
         # Unicode line/paragraph separators can break AppleScript string parsing
-        .replace('\u2028', '\\n')
-        .replace('\u2029', '\\n')
+        .replace("\u2028", "\\n")
+        .replace("\u2029", "\\n")
     )
 
 
@@ -44,30 +45,27 @@ def _sanitize_for_json(text: str) -> str:
     Desktop <-> CLI <-> MCP communication chain.
     """
     # Normalize line endings first (AppleScript uses \r)
-    text = text.replace('\r\n', '\n').replace('\r', '\n')
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
     # Force ASCII: replaces non-ASCII chars with their Unicode escape or drops them
-    text = text.encode('ascii', 'replace').decode('ascii')
+    text = text.encode("ascii", "replace").decode("ascii")
     # Strip remaining control characters (keep \n and \t)
-    return ''.join(
-        ch for ch in text
-        if ch in ('\n', '\t') or (' ' <= ch <= '~')
-    )
+    return "".join(ch for ch in text if ch in ("\n", "\t") or (" " <= ch <= "~"))
 
 
-def run_applescript(script: str) -> str:
-    """Execute AppleScript via stdin pipe for reliable multi-line handling"""
+def run_applescript(script: str, timeout: int = 120) -> str:
+    """Execute AppleScript via stdin pipe for reliable multi-line handling."""
     try:
         result = subprocess.run(
-            ['osascript', '-'],
-            input=script.encode('utf-8'),
+            ["osascript", "-"],
+            input=script.encode("utf-8"),
             capture_output=True,
-            timeout=120
+            timeout=timeout,
         )
         if result.returncode != 0:
-            stderr = result.stderr.decode('utf-8', errors='replace').strip()
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
             if stderr:
                 raise Exception(f"AppleScript error: {stderr}")
-        output = result.stdout.decode('utf-8', errors='replace').strip()
+        output = result.stdout.decode("utf-8", errors="replace").strip()
         return _sanitize_for_json(output)
     except subprocess.TimeoutExpired:
         raise Exception("AppleScript execution timed out")
@@ -75,35 +73,94 @@ def run_applescript(script: str) -> str:
         raise Exception(f"AppleScript execution failed: {str(e)}")
 
 
+def normalize_search_terms(
+    search_term: Optional[str] = None,
+    search_terms: Optional[List[str]] = None,
+) -> List[str]:
+    """Return de-duplicated, non-empty search terms preserving order."""
+    normalized = []
+
+    if search_term and search_term.strip():
+        normalized.append(search_term.strip())
+
+    if search_terms:
+        for term in search_terms:
+            if term and term.strip():
+                normalized.append(term.strip())
+
+    unique_terms = []
+    for term in normalized:
+        if term not in unique_terms:
+            unique_terms.append(term)
+
+    return unique_terms
+
+
+def contains_any_condition(field_name: str, values: List[str]) -> str:
+    """Return AppleScript OR conditions for substring matches."""
+    if not values:
+        return "true"
+
+    escaped_values = [escape_applescript(value) for value in values]
+    parts = [f'{field_name} contains "{value}"' for value in escaped_values]
+    return "(" + " or ".join(parts) + ")"
+
+
+def normalize_message_ids(message_ids: Optional[List[Any]]) -> List[str]:
+    """Return de-duplicated numeric Mail ids as strings preserving order."""
+    if not message_ids:
+        return []
+
+    normalized = []
+    for value in message_ids:
+        value_text = str(value).strip()
+        if value_text and value_text.isdigit() and value_text not in normalized:
+            normalized.append(value_text)
+
+    return normalized
+
+
+def equals_any_numeric_condition(field_name: str, values: List[str]) -> str:
+    """Return AppleScript OR conditions for numeric equality matches."""
+    if not values:
+        return "false"
+
+    parts = [f"{field_name} is {value}" for value in values]
+    return "(" + " or ".join(parts) + ")"
+
+
 def parse_email_list(output: str) -> List[Dict[str, Any]]:
     """Parse the structured email output from AppleScript"""
     emails = []
-    lines = output.split('\n')
+    lines = output.split("\n")
 
     current_email = {}
     for line in lines:
         line = line.strip()
-        if not line or line.startswith('=') or line.startswith('━') or line.startswith('📧') or line.startswith('⚠'):
+        if (
+            not line
+            or line.startswith("=")
+            or line.startswith("━")
+            or line.startswith("📧")
+            or line.startswith("⚠")
+        ):
             continue
 
-        if line.startswith('✉') or line.startswith('✓'):
+        if line.startswith("✉") or line.startswith("✓"):
             # New email entry
             if current_email:
                 emails.append(current_email)
 
-            is_read = line.startswith('✓')
+            is_read = line.startswith("✓")
             subject = line[2:].strip()  # Remove indicator
-            current_email = {
-                'subject': subject,
-                'is_read': is_read
-            }
-        elif line.startswith('From:'):
-            current_email['sender'] = line[5:].strip()
-        elif line.startswith('Date:'):
-            current_email['date'] = line[5:].strip()
-        elif line.startswith('Preview:'):
-            current_email['preview'] = line[8:].strip()
-        elif line.startswith('TOTAL EMAILS'):
+            current_email = {"subject": subject, "is_read": is_read}
+        elif line.startswith("From:"):
+            current_email["sender"] = line[5:].strip()
+        elif line.startswith("Date:"):
+            current_email["date"] = line[5:].strip()
+        elif line.startswith("Preview:"):
+            current_email["preview"] = line[8:].strip()
+        elif line.startswith("TOTAL EMAILS"):
             # End of email list
             if current_email:
                 emails.append(current_email)
@@ -119,27 +176,29 @@ def parse_email_list(output: str) -> List[Dict[str, Any]]:
 # Shared AppleScript template helpers
 # ---------------------------------------------------------------------------
 
-LOWERCASE_HANDLER = '''
+LOWERCASE_HANDLER = """
     on lowercase(str)
         set lowerStr to do shell script "echo " & quoted form of str & " | tr '[:upper:]' '[:lower:]'"
         return lowerStr
     end lowercase
-'''
+"""
 
 
-def inbox_mailbox_script(var_name: str = "inboxMailbox", account_var: str = "anAccount") -> str:
+def inbox_mailbox_script(
+    var_name: str = "inboxMailbox", account_var: str = "anAccount"
+) -> str:
     """Return AppleScript snippet to get inbox mailbox with INBOX/Inbox fallback."""
-    return f'''
+    return f"""
                 try
                     set {var_name} to mailbox "INBOX" of {account_var}
                 on error
                     set {var_name} to mailbox "Inbox" of {account_var}
-                end try'''
+                end try"""
 
 
 def content_preview_script(max_length: int, output_var: str = "outputText") -> str:
     """Return AppleScript snippet to extract and truncate email content preview."""
-    return f'''
+    return f"""
                             try
                                 set msgContent to content of aMessage
                                 set AppleScript's text item delimiters to {{return, linefeed}}
@@ -157,22 +216,23 @@ def content_preview_script(max_length: int, output_var: str = "outputText") -> s
                                 set {output_var} to {output_var} & "   Content: " & contentPreview & return
                             on error
                                 set {output_var} to {output_var} & "   Content: [Not available]" & return
-                            end try'''
+                            end try"""
 
 
 def date_cutoff_script(days_back: int, var_name: str = "cutoffDate") -> str:
     """Return AppleScript snippet to set a date cutoff variable."""
     if days_back <= 0:
         return ""
-    return f'''
-            set {var_name} to (current date) - ({days_back} * days)'''
+    return f"""
+            set {var_name} to (current date) - ({days_back} * days)"""
 
 
 def skip_folders_condition(var_name: str = "mailboxName") -> str:
     """Return AppleScript condition to skip system folders (Trash, Junk, etc)."""
     from apple_mail_mcp.constants import SKIP_FOLDERS
-    folder_list = ', '.join(f'"{f}"' for f in SKIP_FOLDERS)
-    return f'{var_name} is not in {{{folder_list}}}'
+
+    folder_list = ", ".join(f'"{f}"' for f in SKIP_FOLDERS)
+    return f"{var_name} is not in {{{folder_list}}}"
 
 
 def build_mailbox_ref(
@@ -198,7 +258,7 @@ def build_mailbox_ref(
         for i in range(len(parts) - 2, -1, -1):
             ref += f'mailbox "{escape_applescript(parts[i])}" of '
         ref += account_var
-        return f'set {var_name} to {ref}'
+        return f"set {var_name} to {ref}"
 
     return f'''try
                 set {var_name} to mailbox "{escaped}" of {account_var}
@@ -212,8 +272,8 @@ def build_mailbox_ref(
 
 
 def build_filter_condition(
-    subject: str | None = None,
-    sender: str | None = None,
+    subject: Optional[str] = None,
+    sender: Optional[str] = None,
     subject_var: str = "messageSubject",
     sender_var: str = "messageSender",
 ) -> str:
@@ -233,7 +293,7 @@ def build_filter_condition(
 def build_date_filter(
     days_back: int,
     var_name: str = "cutoffDate",
-) -> tuple[str, str]:
+) -> Tuple[str, str]:
     """Return (setup_script, condition_fragment) for a date-based cutoff.
 
     *setup_script* should be placed before the message loop.
@@ -243,7 +303,7 @@ def build_date_filter(
     """
     if days_back <= 0:
         return ("", "")
-    setup = f'set {var_name} to (current date) - ({days_back} * days)'
+    setup = f"set {var_name} to (current date) - ({days_back} * days)"
     condition = f"and messageDate > {var_name}"
     return (setup, condition)
 
@@ -260,15 +320,15 @@ def build_email_fields_script(
     messageRead.  Optionally appends a cleaned content preview to
     *output_var*.
     """
-    fields = f'''set messageSubject to subject of {message_var}
+    fields = f"""set messageSubject to subject of {message_var}
                                 set messageSender to sender of {message_var}
                                 set messageDate to date received of {message_var}
-                                set messageRead to read status of {message_var}'''
+                                set messageRead to read status of {message_var}"""
 
     if not include_content:
         return fields
 
-    content = f'''
+    content = f"""
                                 try
                                     set msgContent to content of {message_var}
                                     set AppleScript's text item delimiters to {{return, linefeed}}
@@ -284,5 +344,5 @@ def build_email_fields_script(
                                     set {output_var} to {output_var} & "   Content: " & contentPreview & return
                                 on error
                                     set {output_var} to {output_var} & "   Content: [Not available]" & return
-                                end try'''
+                                end try"""
     return fields + content

--- a/apple_mail_mcp/tools/compose.py
+++ b/apple_mail_mcp/tools/compose.py
@@ -3,11 +3,242 @@
 import os
 import subprocess
 import tempfile
+import re
+import time
+from email.message import EmailMessage
+from html import escape as html_escape
+from pathlib import Path
 from typing import Optional, List, Tuple
 
-
 from apple_mail_mcp.server import mcp, READ_ONLY
-from apple_mail_mcp.core import inject_preferences, escape_applescript, run_applescript, inbox_mailbox_script
+from apple_mail_mcp.core import (
+    inject_preferences,
+    escape_applescript,
+    run_applescript,
+    inbox_mailbox_script,
+)
+
+
+def _split_addresses(value):
+    """Return trimmed recipient addresses preserving order."""
+    if not value:
+        return []
+    return [addr.strip() for addr in value.split(",") if addr and addr.strip()]
+
+
+def _safe_eml_name(subject):
+    """Return a filesystem-safe filename stem for draft exports."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", (subject or "rich-email-draft").strip())
+    cleaned = cleaned.strip("-._") or "rich-email-draft"
+    return cleaned[:80]
+
+
+def _default_rich_draft_path(subject):
+    """Return default output path for generated rich draft EML files."""
+    drafts_dir = Path.home() / "Library" / "Caches" / "apple-mail-mcp" / "rich-drafts"
+    drafts_dir.mkdir(parents=True, exist_ok=True)
+    return drafts_dir / (_safe_eml_name(subject) + ".eml")
+
+
+def _resolve_sender_address(account):
+    """Return the primary sender address for a Mail account, if available."""
+    safe_account = escape_applescript(account)
+    script = f'''
+    tell application "Mail"
+        try
+            set targetAccount to account "{safe_account}"
+            set emailAddrs to email addresses of targetAccount
+            if (count of emailAddrs) > 0 then
+                return item 1 of emailAddrs
+            end if
+            return ""
+        on error
+            return ""
+        end try
+    end tell
+    '''
+    sender_address = run_applescript(script)
+    sender_address = sender_address.strip()
+    return sender_address or None
+
+
+def _build_html_from_text(text_body):
+    """Return a simple HTML wrapper for plain text content."""
+    safe_body = html_escape(text_body or "")
+    return (
+        '<html><body style="font-family: -apple-system, BlinkMacSystemFont, '
+        "'Segoe UI', Arial, sans-serif; line-height: 1.45; color: #111111;\">"
+        '<pre style="white-space: pre-wrap; font: inherit; margin: 0;">'
+        + safe_body
+        + "</pre></body></html>"
+    )
+
+
+def _prepare_rich_bodies(subject, text_body, html_body):
+    """Return plain-text and HTML bodies, filling sensible placeholders."""
+    plain_body = text_body or ""
+    rich_body = html_body or ""
+
+    if not plain_body and not rich_body:
+        plain_body = (
+            "Draft outline\n\n"
+            "- Add recipients\n"
+            "- Add the final rich-text content\n"
+            "- Review before sending"
+        )
+        rich_body = _build_html_from_text(plain_body)
+        return plain_body, rich_body, ["body"]
+
+    if rich_body and not plain_body:
+        plain_body = (
+            (subject.strip() + "\n\n" if subject and subject.strip() else "")
+            + "This message contains rich HTML content. Open it in Mail for the rendered version."
+        )
+
+    if plain_body and not rich_body:
+        rich_body = _build_html_from_text(plain_body)
+
+    return plain_body, rich_body, []
+
+
+def _save_open_message_as_draft(subject, retries=10, delay_seconds=0.5):
+    """Ask Mail to save the matching open outgoing message as a draft."""
+    if not subject:
+        return False
+
+    safe_subject = escape_applescript(subject)
+    script = f'''
+    tell application "Mail"
+        try
+            set matchingMessages to every outgoing message whose subject is "{safe_subject}"
+            if (count of matchingMessages) is 0 then
+                return "not-found"
+            end if
+            save item 1 of matchingMessages
+            return "saved"
+        on error errMsg
+            return "error: " & errMsg
+        end try
+    end tell
+    '''
+
+    for _ in range(retries):
+        result = run_applescript(script).strip().lower()
+        if result == "saved":
+            return True
+        if result.startswith("error:"):
+            break
+        time.sleep(delay_seconds)
+    return False
+
+
+@mcp.tool()
+@inject_preferences
+def create_rich_email_draft(
+    account: str,
+    subject: str = "",
+    to: Optional[str] = None,
+    text_body: Optional[str] = None,
+    html_body: Optional[str] = None,
+    cc: Optional[str] = None,
+    bcc: Optional[str] = None,
+    output_path: Optional[str] = None,
+    open_in_mail: bool = True,
+    save_as_draft: bool = False,
+) -> str:
+    """
+    Create a rich-text email draft by generating an unsent `.eml` message and optionally opening it in Mail.
+
+    This is the preferred path for HTML or richly formatted emails because Mail reliably renders `.eml`
+    content, while setting raw HTML through AppleScript often stores the literal markup instead.
+
+    Args:
+        account: Account name to use for the sender identity (e.g., "Work", "Oracle")
+        subject: Subject line for the draft (optional; defaults to empty)
+        to: Optional recipient email address(es), comma-separated for multiple
+        text_body: Optional plain-text body. If omitted but html_body is provided, a fallback plain body is generated.
+        html_body: Optional HTML body. If omitted but text_body is provided, a basic HTML wrapper is generated.
+        cc: Optional CC recipients, comma-separated for multiple
+        bcc: Optional BCC recipients, comma-separated for multiple
+        output_path: Optional path for the generated `.eml` file
+        open_in_mail: If True, open the generated `.eml` in Mail (default: True)
+        save_as_draft: If True, ask Mail to save the opened compose window into Drafts (default: False)
+
+    Returns:
+        Confirmation with the generated `.eml` path, missing details, and Mail-open/save status
+    """
+    if not account or not account.strip():
+        return "Error: 'account' is required"
+
+    recipients_to = _split_addresses(to)
+    recipients_cc = _split_addresses(cc)
+    recipients_bcc = _split_addresses(bcc)
+    plain_body, rich_body, body_missing = _prepare_rich_bodies(
+        subject, text_body, html_body
+    )
+
+    missing_details = []
+    if not subject or not subject.strip():
+        missing_details.append("subject")
+    if not recipients_to:
+        missing_details.append("to")
+    missing_details.extend(body_missing)
+
+    sender_address = _resolve_sender_address(account)
+    message = EmailMessage()
+    if subject:
+        message["Subject"] = subject
+    if sender_address:
+        message["From"] = sender_address
+    if recipients_to:
+        message["To"] = ", ".join(recipients_to)
+    if recipients_cc:
+        message["Cc"] = ", ".join(recipients_cc)
+    if recipients_bcc:
+        message["Bcc"] = ", ".join(recipients_bcc)
+    message["X-Unsent"] = "1"
+    message.set_content(plain_body)
+    message.add_alternative(rich_body, subtype="html")
+
+    draft_path = (
+        Path(output_path).expanduser()
+        if output_path
+        else _default_rich_draft_path(subject)
+    )
+    draft_path.parent.mkdir(parents=True, exist_ok=True)
+    draft_path.write_bytes(bytes(message))
+
+    opened = False
+    saved = False
+    if open_in_mail:
+        subprocess.run(["open", "-a", "Mail", str(draft_path)], check=True)
+        opened = True
+        if save_as_draft:
+            saved = _save_open_message_as_draft(subject)
+
+    output_lines = ["RICH EMAIL DRAFT", "", "✓ Rich draft prepared successfully!", ""]
+    output_lines.append("Account: " + account)
+    output_lines.append("Subject: " + (subject if subject else "[empty]"))
+    output_lines.append("EML path: " + str(draft_path))
+    output_lines.append("Opened in Mail: " + ("yes" if opened else "no"))
+    if open_in_mail:
+        output_lines.append("Saved in Drafts: " + ("yes" if saved else "no"))
+    if sender_address:
+        output_lines.append("From: " + sender_address)
+    if recipients_to:
+        output_lines.append("To: " + ", ".join(recipients_to))
+    if recipients_cc:
+        output_lines.append("CC: " + ", ".join(recipients_cc))
+    if recipients_bcc:
+        output_lines.append("BCC: " + ", ".join(recipients_bcc))
+    output_lines.append(
+        "Missing details: "
+        + (", ".join(missing_details) if missing_details else "none")
+    )
+    output_lines.append(
+        "Note: Prefer this `.eml` workflow for HTML email drafts; Mail renders it more reliably than raw HTML injected via AppleScript content."
+    )
+    return "\n".join(output_lines)
 
 
 def _send_html_email(
@@ -47,27 +278,32 @@ def _send_html_email(
 
     # Mode-specific behaviour after paste
     if mode == "send":
-        post_paste_script = '''
+        post_paste_script = """
             -- Send via keyboard shortcut
             keystroke "d" using {command down, shift down}
-        '''
+        """
         success_text = "Email sent successfully (HTML)"
     elif mode == "draft":
-        post_paste_script = '''
+        post_paste_script = """
             -- Save as draft: Cmd+S then close
             keystroke "s" using command down
             delay 0.5
-        '''
+        """
         success_text = "Email saved as draft (HTML)"
     else:  # open
         post_paste_script = "-- Leaving open for review"
-        success_text = "Email opened in Mail for review (HTML). Edit and send when ready."
+        success_text = (
+            "Email opened in Mail for review (HTML). Edit and send when ready."
+        )
 
     # Write HTML to temp file so the AppleScript can read it without
     # worrying about escaping quotes/special chars in the HTML string.
     tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".html", prefix="mail_html_",
-        delete=False, encoding="utf-8",
+        mode="w",
+        suffix=".html",
+        prefix="mail_html_",
+        delete=False,
+        encoding="utf-8",
     )
     tmp.write(body_html)
     tmp.close()
@@ -178,20 +414,20 @@ def _validate_attachment_paths(attachments: str) -> Tuple[List[str], Optional[st
         A tuple of (resolved_paths, error_message).
         If error_message is not None, resolved_paths should be ignored.
     """
-    home_dir = os.path.expanduser('~')
+    home_dir = os.path.expanduser("~")
     sensitive_dirs = [
-        os.path.join(home_dir, '.ssh'),
-        os.path.join(home_dir, '.gnupg'),
-        os.path.join(home_dir, '.config'),
-        os.path.join(home_dir, '.aws'),
-        os.path.join(home_dir, '.claude'),
-        os.path.join(home_dir, 'Library', 'LaunchAgents'),
-        os.path.join(home_dir, 'Library', 'LaunchDaemons'),
-        os.path.join(home_dir, 'Library', 'Keychains'),
+        os.path.join(home_dir, ".ssh"),
+        os.path.join(home_dir, ".gnupg"),
+        os.path.join(home_dir, ".config"),
+        os.path.join(home_dir, ".aws"),
+        os.path.join(home_dir, ".claude"),
+        os.path.join(home_dir, "Library", "LaunchAgents"),
+        os.path.join(home_dir, "Library", "LaunchDaemons"),
+        os.path.join(home_dir, "Library", "Keychains"),
     ]
 
     resolved_paths: List[str] = []
-    raw_paths = [p.strip() for p in attachments.split(',')]
+    raw_paths = [p.strip() for p in attachments.split(",")]
 
     for raw_path in raw_paths:
         if not raw_path:
@@ -203,12 +439,18 @@ def _validate_attachment_paths(attachments: str) -> Tuple[List[str], Optional[st
 
         # Must be under the user's home directory
         if not resolved.startswith(home_dir + os.sep) and resolved != home_dir:
-            return [], f"Error: Attachment path must be under your home directory ({home_dir}). Got: {resolved}"
+            return (
+                [],
+                f"Error: Attachment path must be under your home directory ({home_dir}). Got: {resolved}",
+            )
 
         # Block sensitive directories
         for sensitive_dir in sensitive_dirs:
             if resolved.startswith(sensitive_dir + os.sep) or resolved == sensitive_dir:
-                return [], f"Error: Cannot attach files from sensitive directory: {sensitive_dir}"
+                return (
+                    [],
+                    f"Error: Cannot attach files from sensitive directory: {sensitive_dir}",
+                )
 
         # File must exist
         if not os.path.isfile(resolved):
@@ -233,7 +475,7 @@ def reply_to_email(
     bcc: Optional[str] = None,
     send: bool = True,
     mode: Optional[str] = None,
-    attachments: Optional[str] = None
+    attachments: Optional[str] = None,
 ) -> str:
     """
     Reply to an email matching a subject keyword.
@@ -260,8 +502,11 @@ def reply_to_email(
     # Write reply body to a temp file to avoid AppleScript string escaping
     # issues with special characters (em dashes, curly quotes, colons, etc.)
     body_tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".txt", prefix="mail_reply_",
-        delete=False, encoding="utf-8",
+        mode="w",
+        suffix=".txt",
+        prefix="mail_reply_",
+        delete=False,
+        encoding="utf-8",
     )
     body_tmp.write(reply_body)
     body_tmp.close()
@@ -269,14 +514,14 @@ def reply_to_email(
 
     # Build the reply command based on reply_to_all flag
     if reply_to_all:
-        reply_command = 'set replyMessage to reply foundMessage with opening window and reply to all'
+        reply_command = "set replyMessage to reply foundMessage with opening window and reply to all"
     else:
-        reply_command = 'set replyMessage to reply foundMessage with opening window'
+        reply_command = "set replyMessage to reply foundMessage with opening window"
 
     # Build CC recipients if provided
-    cc_script = ''
+    cc_script = ""
     if cc:
-        cc_addresses = [addr.strip() for addr in cc.split(',')]
+        cc_addresses = [addr.strip() for addr in cc.split(",")]
         for addr in cc_addresses:
             safe_addr = escape_applescript(addr)
             cc_script += f'''
@@ -284,9 +529,9 @@ def reply_to_email(
             '''
 
     # Build BCC recipients if provided
-    bcc_script = ''
+    bcc_script = ""
     if bcc:
-        bcc_addresses = [addr.strip() for addr in bcc.split(',')]
+        bcc_addresses = [addr.strip() for addr in bcc.split(",")]
         for addr in bcc_addresses:
             safe_addr = escape_applescript(addr)
             bcc_script += f'''
@@ -294,8 +539,8 @@ def reply_to_email(
             '''
 
     # Build attachment script if provided
-    attachment_script = ''
-    attachment_info = ''
+    attachment_script = ""
+    attachment_info = ""
     if attachments:
         validated_paths, error = _validate_attachment_paths(attachments)
         if error:
@@ -307,11 +552,13 @@ def reply_to_email(
                 make new attachment with properties {{file name:theFile}} at after the last paragraph
                 delay 1
             '''
-            attachment_info += f'  {path}\n'
+            attachment_info += f"  {path}\n"
 
     safe_cc = escape_applescript(cc) if cc else ""
     safe_bcc = escape_applescript(bcc) if bcc else ""
-    safe_attachment_info = escape_applescript(attachment_info) if attachment_info else ""
+    safe_attachment_info = (
+        escape_applescript(attachment_info) if attachment_info else ""
+    )
 
     # Resolve delivery mode: mode parameter takes precedence over send boolean
     if mode is not None:
@@ -330,13 +577,13 @@ def reply_to_email(
         send_or_draft_command = "send replyMessage"
         success_text = "Reply sent successfully!"
         # For send, Mail handles the quoted original via the HTML layer
-        set_content_script = 'set content of replyMessage to replyBodyText'
+        set_content_script = "set content of replyMessage to replyBodyText"
     elif effective_mode == "open":
         header_text = "OPENING REPLY FOR REVIEW"
         # For open, we use the clipboard to paste the reply body.
         # This preserves Mail.app's native quoted original
         # (setting content via AppleScript overwrites the async HTML layer).
-        send_or_draft_command = f'''
+        send_or_draft_command = f"""
                 set visible of replyMessage to true
                 activate
                 delay 1.5
@@ -347,9 +594,9 @@ def reply_to_email(
                         keystroke "v" using command down
                     end tell
                 end tell
-                delay 0.5'''
+                delay 0.5"""
         success_text = "Reply opened in Mail for review. Edit and send when ready."
-        set_content_script = '-- content set via clipboard paste'
+        set_content_script = "-- content set via clipboard paste"
     else:  # draft
         header_text = "SAVING REPLY AS DRAFT"
         send_or_draft_command = "close window 1 saving yes"
@@ -357,11 +604,11 @@ def reply_to_email(
         # For draft, we must manually build the quoted original because
         # close-window-saving-yes saves the content property literally
         # and the reply message's content property is initially empty
-        set_content_script = '''set origContent to content of foundMessage
+        set_content_script = """set origContent to content of foundMessage
                 set origSender to sender of foundMessage
                 set origDate to date received of foundMessage
                 set quotedText to "On " & (origDate as string) & ", " & origSender & " wrote:" & return & return & origContent
-                set content of replyMessage to replyBodyText & return & return & quotedText'''
+                set content of replyMessage to replyBodyText & return & return & quotedText"""
 
     cleanup_script = f'do shell script "rm -f " & quoted form of "{body_temp_path}"'
 
@@ -428,21 +675,21 @@ def reply_to_email(
     '''
 
     if cc:
-        script += f'''
+        script += f"""
                 set outputText to outputText & "CC: {safe_cc}" & return
-    '''
+    """
 
     if bcc:
-        script += f'''
+        script += f"""
                 set outputText to outputText & "BCC: {safe_bcc}" & return
-    '''
+    """
 
     if attachments:
         script += f'''
                 set outputText to outputText & "Attachments:" & return & "{safe_attachment_info}" & return
     '''
 
-    script += f'''
+    script += f"""
             else
                 set outputText to outputText & "No email found matching: {safe_subject_keyword}" & return
             end if
@@ -460,7 +707,7 @@ def reply_to_email(
 
         return outputText
     end tell
-    '''
+    """
 
     try:
         result = run_applescript(script)
@@ -482,7 +729,7 @@ def compose_email(
     bcc: Optional[str] = None,
     attachments: Optional[str] = None,
     mode: str = "send",
-    body_html: Optional[str] = None
+    body_html: Optional[str] = None,
 ) -> str:
     """
     Compose and send a new email from a specific account.
@@ -507,8 +754,8 @@ def compose_email(
         return f"Error: Invalid mode '{mode}'. Use: send, draft, open"
 
     # Validate and resolve attachments early
-    attachment_script = ''
-    attachment_info = ''
+    attachment_script = ""
+    attachment_info = ""
     if attachments:
         validated_paths, error = _validate_attachment_paths(attachments)
         if error:
@@ -520,7 +767,7 @@ def compose_email(
                 make new attachment with properties {{file name:theFile}} at after the last paragraph
                 delay 1
             '''
-            attachment_info += f'  {path}\n'
+            attachment_info += f"  {path}\n"
 
     # --- HTML path: use NSPasteboard clipboard injection ---
     if body_html:
@@ -542,8 +789,8 @@ def compose_email(
     escaped_body = escape_applescript(body)
 
     # Build TO recipients (split comma-separated addresses)
-    to_script = ''
-    to_addresses = [addr.strip() for addr in to.split(',')]
+    to_script = ""
+    to_addresses = [addr.strip() for addr in to.split(",")]
     for addr in to_addresses:
         safe_addr = escape_applescript(addr)
         to_script += f'''
@@ -551,9 +798,9 @@ def compose_email(
         '''
 
     # Build CC recipients if provided
-    cc_script = ''
+    cc_script = ""
     if cc:
-        cc_addresses = [addr.strip() for addr in cc.split(',')]
+        cc_addresses = [addr.strip() for addr in cc.split(",")]
         for addr in cc_addresses:
             safe_addr = escape_applescript(addr)
             cc_script += f'''
@@ -561,9 +808,9 @@ def compose_email(
             '''
 
     # Build BCC recipients if provided
-    bcc_script = ''
+    bcc_script = ""
     if bcc:
-        bcc_addresses = [addr.strip() for addr in bcc.split(',')]
+        bcc_addresses = [addr.strip() for addr in bcc.split(",")]
         for addr in bcc_addresses:
             safe_addr = escape_applescript(addr)
             bcc_script += f'''
@@ -573,7 +820,9 @@ def compose_email(
     safe_to = escape_applescript(to)
     safe_cc = escape_applescript(cc) if cc else ""
     safe_bcc = escape_applescript(bcc) if bcc else ""
-    safe_attachment_info = escape_applescript(attachment_info) if attachment_info else ""
+    safe_attachment_info = (
+        escape_applescript(attachment_info) if attachment_info else ""
+    )
 
     # Determine behavior per mode
     if mode == "send":
@@ -628,14 +877,14 @@ def compose_email(
     '''
 
     if cc:
-        script += f'''
+        script += f"""
             set outputText to outputText & "CC: {safe_cc}" & return
-    '''
+    """
 
     if bcc:
-        script += f'''
+        script += f"""
             set outputText to outputText & "BCC: {safe_bcc}" & return
-    '''
+    """
 
     if attachments:
         script += f'''
@@ -667,7 +916,7 @@ def forward_email(
     message: Optional[str] = None,
     mailbox: str = "INBOX",
     cc: Optional[str] = None,
-    bcc: Optional[str] = None
+    bcc: Optional[str] = None,
 ) -> str:
     """
     Forward an email to one or more recipients.
@@ -693,9 +942,9 @@ def forward_email(
     escaped_message = escape_applescript(message) if message else ""
 
     # Build CC recipients if provided
-    cc_script = ''
+    cc_script = ""
     if cc:
-        cc_addresses = [addr.strip() for addr in cc.split(',')]
+        cc_addresses = [addr.strip() for addr in cc.split(",")]
         for addr in cc_addresses:
             safe_addr = escape_applescript(addr)
             cc_script += f'''
@@ -703,9 +952,9 @@ def forward_email(
             '''
 
     # Build BCC recipients if provided
-    bcc_script = ''
+    bcc_script = ""
     if bcc:
-        bcc_addresses = [addr.strip() for addr in bcc.split(',')]
+        bcc_addresses = [addr.strip() for addr in bcc.split(",")]
         for addr in bcc_addresses:
             safe_addr = escape_applescript(addr)
             bcc_script += f'''
@@ -716,8 +965,8 @@ def forward_email(
     safe_bcc = escape_applescript(bcc) if bcc else ""
 
     # Build TO recipients (split comma-separated)
-    to_script = ''
-    to_addresses = [addr.strip() for addr in to.split(',')]
+    to_script = ""
+    to_addresses = [addr.strip() for addr in to.split(",")]
     for addr in to_addresses:
         safe_addr = escape_applescript(addr)
         to_script += f'''
@@ -793,16 +1042,16 @@ def forward_email(
     '''
 
     if cc:
-        script += f'''
+        script += f"""
                 set outputText to outputText & "CC: {safe_cc}" & return
-    '''
+    """
 
     if bcc:
-        script += f'''
+        script += f"""
                 set outputText to outputText & "BCC: {safe_bcc}" & return
-    '''
+    """
 
-    script += f'''
+    script += f"""
             else
                 set outputText to outputText & "⚠ No email found matching: {safe_subject_keyword}" & return
             end if
@@ -813,7 +1062,7 @@ def forward_email(
 
         return outputText
     end tell
-    '''
+    """
 
     result = run_applescript(script)
     return result
@@ -829,7 +1078,7 @@ def manage_drafts(
     body: Optional[str] = None,
     cc: Optional[str] = None,
     bcc: Optional[str] = None,
-    draft_subject: Optional[str] = None
+    draft_subject: Optional[str] = None,
 ) -> str:
     """
     Manage draft emails - list, create, send, open, or delete drafts.
@@ -891,8 +1140,8 @@ def manage_drafts(
         safe_to = escape_applescript(to)
 
         # Build TO recipients (split comma-separated)
-        to_script = ''
-        to_addresses = [addr.strip() for addr in to.split(',')]
+        to_script = ""
+        to_addresses = [addr.strip() for addr in to.split(",")]
         for addr in to_addresses:
             safe_addr = escape_applescript(addr)
             to_script += f'''
@@ -900,9 +1149,9 @@ def manage_drafts(
             '''
 
         # Build CC recipients if provided
-        cc_script = ''
+        cc_script = ""
         if cc:
-            cc_addresses = [addr.strip() for addr in cc.split(',')]
+            cc_addresses = [addr.strip() for addr in cc.split(",")]
             for addr in cc_addresses:
                 safe_addr = escape_applescript(addr)
                 cc_script += f'''
@@ -910,9 +1159,9 @@ def manage_drafts(
                 '''
 
         # Build BCC recipients if provided
-        bcc_script = ''
+        bcc_script = ""
         if bcc:
-            bcc_addresses = [addr.strip() for addr in bcc.split(',')]
+            bcc_addresses = [addr.strip() for addr in bcc.split(",")]
             for addr in bcc_addresses:
                 safe_addr = escape_applescript(addr)
                 bcc_script += f'''
@@ -1108,7 +1357,9 @@ def manage_drafts(
         '''
 
     else:
-        return f"Error: Invalid action '{action}'. Use: list, create, send, open, delete"
+        return (
+            f"Error: Invalid action '{action}'. Use: list, create, send, open, delete"
+        )
 
     result = run_applescript(script)
     return result

--- a/apple_mail_mcp/tools/inbox.py
+++ b/apple_mail_mcp/tools/inbox.py
@@ -4,7 +4,12 @@ import json
 from typing import Optional, List, Dict, Any
 
 from apple_mail_mcp.server import mcp
-from apple_mail_mcp.core import inject_preferences, escape_applescript, run_applescript, inbox_mailbox_script
+from apple_mail_mcp.core import (
+    inject_preferences,
+    escape_applescript,
+    run_applescript,
+    inbox_mailbox_script,
+)
 
 
 def _parse_pipe_delimited_emails(raw: str) -> List[Dict[str, Any]]:
@@ -12,18 +17,20 @@ def _parse_pipe_delimited_emails(raw: str) -> List[Dict[str, Any]]:
     emails = []
     if not raw:
         return emails
-    for line in raw.split('\n'):
-        if '|||' not in line:
+    for line in raw.split("\n"):
+        if "|||" not in line:
             continue
-        parts = line.split('|||')
+        parts = line.split("|||")
         if len(parts) >= 5:
-            emails.append({
-                'subject': parts[0].strip(),
-                'sender': parts[1].strip(),
-                'date': parts[2].strip(),
-                'is_read': parts[3].strip().lower() == 'true',
-                'account': parts[4].strip(),
-            })
+            emails.append(
+                {
+                    "subject": parts[0].strip(),
+                    "sender": parts[1].strip(),
+                    "date": parts[2].strip(),
+                    "is_read": parts[3].strip().lower() == "true",
+                    "account": parts[4].strip(),
+                }
+            )
     return emails
 
 
@@ -51,7 +58,7 @@ def list_inbox_emails(
     if output_format == "json":
         return _list_inbox_emails_json(account, max_emails, include_read)
 
-    script = f'''
+    script = f"""
     tell application "Mail"
         set outputText to "INBOX EMAILS - ALL ACCOUNTS" & return & return
         set totalCount to 0
@@ -115,7 +122,7 @@ def list_inbox_emails(
 
         return outputText
     end tell
-    '''
+    """
 
     result = run_applescript(script)
     return result
@@ -128,10 +135,10 @@ def _list_inbox_emails_json(
 ) -> str:
     """Return inbox emails as a JSON string."""
     escaped_account = escape_applescript(account) if account else None
-    account_filter = f'if accountName is "{escaped_account}" then' if account else ''
-    account_filter_end = 'end if' if account else ''
+    account_filter = f'if accountName is "{escaped_account}" then' if account else ""
+    account_filter_end = "end if" if account else ""
 
-    script = f'''
+    script = f"""
     tell application "Mail"
         set resultLines to {{}}
         set allAccounts to every account
@@ -165,7 +172,7 @@ def _list_inbox_emails_json(
         set AppleScript's text item delimiters to linefeed
         return resultLines as string
     end tell
-    '''
+    """
     raw = run_applescript(script)
     emails = _parse_pipe_delimited_emails(raw)
     return json.dumps(emails, indent=2)
@@ -181,9 +188,9 @@ def get_unread_count() -> Dict[str, int]:
         Dictionary mapping account names to unread email counts
     """
 
-    script = '''
+    script = f"""
     tell application "Mail"
-        set resultList to {}
+        set resultList to {{}}
         set allAccounts to every account
 
         repeat with anAccount in allAccounts
@@ -201,19 +208,111 @@ def get_unread_count() -> Dict[str, int]:
         set AppleScript's text item delimiters to "|"
         return resultList as string
     end tell
-    '''
+    """
 
     result = run_applescript(script)
 
     # Parse the result
     counts = {}
-    for item in result.split('|'):
-        if ':' in item:
-            account, count = item.split(':', 1)
+    for item in result.split("|"):
+        if ":" in item:
+            account, count = item.split(":", 1)
             if count != "ERROR":
                 counts[account] = int(count)
             else:
                 counts[account] = -1  # Error indicator
+
+    return counts
+
+
+@mcp.tool()
+@inject_preferences
+def get_mailbox_unread_counts(
+    account: Optional[str] = None,
+    include_zero: bool = False,
+) -> Dict[str, Dict[str, int]]:
+    """
+    Get unread counts per mailbox for one account or all accounts.
+
+    Args:
+        account: Optional account name filter
+        include_zero: Whether to include mailboxes with zero unread messages
+
+    Returns:
+        Nested dictionary keyed by account name then mailbox path
+    """
+    escaped_account = escape_applescript(account) if account else None
+
+    account_filter = (
+        f'''
+            if accountName is not "{escaped_account}" then
+                set shouldIncludeAccount to false
+            end if
+    '''
+        if account
+        else ""
+    )
+
+    script = f"""
+    tell application "Mail"
+        set resultList to {{}}
+        set allAccounts to every account
+
+        repeat with anAccount in allAccounts
+            set accountName to name of anAccount
+            set shouldIncludeAccount to true
+            {account_filter}
+
+            if shouldIncludeAccount then
+                try
+                    set accountMailboxes to every mailbox of anAccount
+
+                    repeat with aMailbox in accountMailboxes
+                        try
+                            set mailboxName to name of aMailbox
+                            set unreadCount to unread count of aMailbox
+                            if {str(include_zero).lower()} or unreadCount > 0 then
+                                set end of resultList to accountName & "|||" & mailboxName & "|||" & unreadCount
+                            end if
+
+                            try
+                                set subMailboxes to every mailbox of aMailbox
+                                repeat with subBox in subMailboxes
+                                    set subName to name of subBox
+                                    set subUnread to unread count of subBox
+                                    if {str(include_zero).lower()} or subUnread > 0 then
+                                        set end of resultList to accountName & "|||" & mailboxName & "/" & subName & "|||" & subUnread
+                                    end if
+                                end repeat
+                            end try
+                        end try
+                    end repeat
+                end try
+            end if
+        end repeat
+
+        if (count of resultList) is 0 then
+            return ""
+        end if
+
+        set AppleScript's text item delimiters to linefeed
+        set outputText to resultList as string
+        set AppleScript's text item delimiters to ""
+        return outputText
+    end tell
+    """
+
+    result = run_applescript(script)
+    counts: Dict[str, Dict[str, int]] = {}
+    if not result:
+        return counts
+
+    for line in result.splitlines():
+        parts = line.split("|||", 2)
+        if len(parts) != 3:
+            continue
+        account_name, mailbox_name, unread_value = parts
+        counts.setdefault(account_name, {})[mailbox_name] = int(unread_value)
 
     return counts
 
@@ -228,7 +327,7 @@ def list_accounts() -> List[str]:
         List of account names
     """
 
-    script = '''
+    script = """
     tell application "Mail"
         set accountNames to {}
         set allAccounts to every account
@@ -241,10 +340,10 @@ def list_accounts() -> List[str]:
         set AppleScript's text item delimiters to "|"
         return accountNames as string
     end tell
-    '''
+    """
 
     result = run_applescript(script)
-    return result.split('|') if result else []
+    return result.split("|") if result else []
 
 
 @mcp.tool()
@@ -274,7 +373,8 @@ def get_recent_emails(
     # Escape user inputs for AppleScript
     escaped_account = escape_applescript(account)
 
-    content_script = '''
+    content_script = (
+        """
         try
             set msgContent to content of aMessage
             set AppleScript's text item delimiters to {{return, linefeed}}
@@ -293,7 +393,10 @@ def get_recent_emails(
         on error
             set outputText to outputText & "   Preview: [Not available]" & return
         end try
-    ''' if include_content else ''
+    """
+        if include_content
+        else ""
+    )
 
     script = f'''
     tell application "Mail"
@@ -383,10 +486,7 @@ def _get_recent_emails_json(account: str, count: int) -> str:
 
 @mcp.tool()
 @inject_preferences
-def list_mailboxes(
-    account: Optional[str] = None,
-    include_counts: bool = True
-) -> str:
+def list_mailboxes(account: Optional[str] = None, include_counts: bool = True) -> str:
     """
     List all mailboxes (folders) for a specific account or all accounts.
 
@@ -399,7 +499,8 @@ def list_mailboxes(
         For nested mailboxes, shows both indented format and path format (e.g., "Projects/Amplify Impact")
     """
 
-    count_script = '''
+    count_script = (
+        """
         try
             set msgCount to count of messages of aMailbox
             set unreadCount to unread count of aMailbox
@@ -407,18 +508,25 @@ def list_mailboxes(
         on error
             set outputText to outputText & " (count unavailable)"
         end try
-    ''' if include_counts else ''
+    """
+        if include_counts
+        else ""
+    )
 
     # Escape user inputs for AppleScript
     escaped_account = escape_applescript(account) if account else None
 
-    account_filter = f'''
+    account_filter = (
+        f'''
         if accountName is "{escaped_account}" then
-    ''' if account else ''
+    '''
+        if account
+        else ""
+    )
 
-    account_filter_end = 'end if' if account else ''
+    account_filter_end = "end if" if account else ""
 
-    script = f'''
+    script = f"""
     tell application "Mail"
         set outputText to "MAILBOXES" & return & return
         set allAccounts to every account
@@ -449,7 +557,7 @@ def list_mailboxes(
                                 set subName to name of subBox
                                 set outputText to outputText & "    └─ " & subName & " [Path: " & mailboxName & "/" & subName & "]"
 
-                                {count_script.replace('aMailbox', 'subBox') if include_counts else ''}
+                                {count_script.replace("aMailbox", "subBox") if include_counts else ""}
 
                                 set outputText to outputText & return
                             end repeat
@@ -465,7 +573,7 @@ def list_mailboxes(
 
         return outputText
     end tell
-    '''
+    """
 
     result = run_applescript(script)
     return result
@@ -487,7 +595,7 @@ def get_inbox_overview() -> str:
     to suggest relevant actions based on the current state.
     """
 
-    script = f'''
+    script = f"""
     tell application "Mail"
         set outputText to "╔══════════════════════════════════════════╗" & return
         set outputText to outputText & "║      EMAIL INBOX OVERVIEW                ║" & return
@@ -652,7 +760,7 @@ def get_inbox_overview() -> str:
 
         return outputText
     end tell
-    '''
+    """
 
     result = run_applescript(script)
     return result

--- a/apple_mail_mcp/tools/manage.py
+++ b/apple_mail_mcp/tools/manage.py
@@ -1,12 +1,16 @@
 """Management tools: moving, status updates, trash, and attachments."""
 
 import os
-from typing import Optional
+from typing import Optional, List
 
 from apple_mail_mcp.server import mcp
 from apple_mail_mcp.core import (
+    contains_any_condition,
+    equals_any_numeric_condition,
     inject_preferences,
     escape_applescript,
+    normalize_message_ids,
+    normalize_search_terms,
     run_applescript,
     inbox_mailbox_script,
     build_mailbox_ref,
@@ -18,113 +22,121 @@ from apple_mail_mcp.core import (
 @inject_preferences
 def move_email(
     account: str,
-    subject_keyword: str,
+    subject_keyword: Optional[str],
     to_mailbox: str,
     from_mailbox: str = "INBOX",
-    max_moves: int = 1
+    max_moves: int = 1,
+    subject_keywords: Optional[List[str]] = None,
 ) -> str:
     """
     Move email(s) matching a subject keyword from one mailbox to another.
 
     Args:
         account: Account name (e.g., "Gmail", "Work")
-        subject_keyword: Keyword to search for in email subjects
+        subject_keyword: Optional keyword to search for in email subjects
         to_mailbox: Destination mailbox name. For nested mailboxes, use "/" separator (e.g., "Projects/Amplify Impact")
         from_mailbox: Source mailbox name (default: "INBOX")
         max_moves: Maximum number of emails to move (default: 1, safety limit)
+        subject_keywords: Optional list of keywords to match in subjects; matches any keyword
 
     Returns:
         Confirmation message with details of moved emails
     """
 
+    subject_terms = normalize_search_terms(subject_keyword, subject_keywords)
+    if not subject_terms:
+        return "Error: 'subject_keyword' or 'subject_keywords' is required"
+
     # Escape all user inputs for AppleScript
     safe_account = escape_applescript(account)
-    safe_subject_keyword = escape_applescript(subject_keyword)
     safe_from_mailbox = escape_applescript(from_mailbox)
     safe_to_mailbox = escape_applescript(to_mailbox)
+    subject_condition = contains_any_condition("subject", subject_terms)
 
     # Parse nested mailbox path
-    mailbox_parts = to_mailbox.split('/')
+    mailbox_parts = to_mailbox.split("/")
 
     # Build the nested mailbox reference
     if len(mailbox_parts) > 1:
         # Nested mailbox
         dest_mailbox_script = f'mailbox "{escape_applescript(mailbox_parts[-1])}" of '
         for i in range(len(mailbox_parts) - 2, -1, -1):
-            dest_mailbox_script += f'mailbox "{escape_applescript(mailbox_parts[i])}" of '
-        dest_mailbox_script += 'targetAccount'
+            dest_mailbox_script += (
+                f'mailbox "{escape_applescript(mailbox_parts[i])}" of '
+            )
+        dest_mailbox_script += "targetAccount"
     else:
         dest_mailbox_script = f'mailbox "{safe_to_mailbox}" of targetAccount'
 
     script = f'''
     tell application "Mail"
-        set outputText to "MOVING EMAILS" & return & return
-        set movedCount to 0
+        with timeout of 300 seconds
+            set outputText to "MOVING EMAILS" & return & return
+            set movedCount to 0
 
-        try
-            set targetAccount to account "{safe_account}"
-            -- Try to get source mailbox (handle both "INBOX"/"Inbox" variations)
             try
-                set sourceMailbox to mailbox "{safe_from_mailbox}" of targetAccount
-            on error
-                if "{safe_from_mailbox}" is "INBOX" then
-                    set sourceMailbox to mailbox "Inbox" of targetAccount
-                else
-                    error "Source mailbox not found"
-                end if
-            end try
-
-            -- Get destination mailbox (handles nested mailboxes)
-            set destMailbox to {dest_mailbox_script}
-            set sourceMessages to every message of sourceMailbox
-
-            repeat with aMessage in sourceMessages
-                if movedCount >= {max_moves} then exit repeat
-
+                set targetAccount to account "{safe_account}"
+                -- Try to get source mailbox (handle both "INBOX"/"Inbox" variations)
                 try
-                    set messageSubject to subject of aMessage
+                    set sourceMailbox to mailbox "{safe_from_mailbox}" of targetAccount
+                on error
+                    if "{safe_from_mailbox}" is "INBOX" then
+                        set sourceMailbox to mailbox "Inbox" of targetAccount
+                    else
+                        error "Source mailbox not found"
+                    end if
+                end try
 
-                    -- Check if subject contains keyword (case insensitive)
-                    if messageSubject contains "{safe_subject_keyword}" then
+                -- Get destination mailbox (handles nested mailboxes)
+                set destMailbox to {dest_mailbox_script}
+                set matchingMessages to every message of sourceMailbox whose {subject_condition}
+                set matchingCount to count of matchingMessages
+
+                if matchingCount is 0 then
+                    set targetMessages to {{}}
+                else if matchingCount > {max_moves} then
+                    set targetMessages to items 1 thru {max_moves} of matchingMessages
+                else
+                    set targetMessages to matchingMessages
+                end if
+
+                repeat with aMessage in targetMessages
+                    try
+                        set messageSubject to subject of aMessage
                         set messageSender to sender of aMessage
                         set messageDate to date received of aMessage
 
-                        -- Move the message
                         move aMessage to destMailbox
+                        set movedCount to movedCount + 1
 
                         set outputText to outputText & "✓ Moved: " & messageSubject & return
                         set outputText to outputText & "  From: " & messageSender & return
                         set outputText to outputText & "  Date: " & (messageDate as string) & return
                         set outputText to outputText & "  {safe_from_mailbox} → {safe_to_mailbox}" & return & return
+                    end try
+                end repeat
 
-                        set movedCount to movedCount + 1
-                    end if
-                end try
-            end repeat
+                set outputText to outputText & "========================================" & return
+                set outputText to outputText & "TOTAL MOVED: " & movedCount & " email(s)" & return
+                set outputText to outputText & "========================================" & return
 
-            set outputText to outputText & "========================================" & return
-            set outputText to outputText & "TOTAL MOVED: " & movedCount & " email(s)" & return
-            set outputText to outputText & "========================================" & return
+            on error errMsg
+                return "Error: " & errMsg & return & "Please check that account and mailbox names are correct. For nested mailboxes, use '/' separator (e.g., 'Projects/Amplify Impact')."
+            end try
 
-        on error errMsg
-            return "Error: " & errMsg & return & "Please check that account and mailbox names are correct. For nested mailboxes, use '/' separator (e.g., 'Projects/Amplify Impact')."
-        end try
-
-        return outputText
+            return outputText
+        end timeout
     end tell
     '''
 
-    result = run_applescript(script)
+    result = run_applescript(script, timeout=300)
     return result
 
 
 @mcp.tool()
 @inject_preferences
 def save_email_attachment(
-    account: str,
-    subject_keyword: str,
-    attachment_name: str,
-    save_path: str
+    account: str, subject_keyword: str, attachment_name: str, save_path: str
 ) -> str:
     """
     Save a specific attachment from an email to disk.
@@ -144,7 +156,7 @@ def save_email_attachment(
 
     # Path validation: resolve to absolute path and enforce safety constraints
     resolved_path = os.path.realpath(expanded_path)
-    home_dir = os.path.expanduser('~')
+    home_dir = os.path.expanduser("~")
 
     # Must be under the user's home directory
     if not resolved_path.startswith(home_dir + os.sep) and resolved_path != home_dir:
@@ -152,17 +164,20 @@ def save_email_attachment(
 
     # Block sensitive directories
     sensitive_dirs = [
-        os.path.join(home_dir, '.ssh'),
-        os.path.join(home_dir, '.gnupg'),
-        os.path.join(home_dir, '.config'),
-        os.path.join(home_dir, '.aws'),
-        os.path.join(home_dir, '.claude'),
-        os.path.join(home_dir, 'Library', 'LaunchAgents'),
-        os.path.join(home_dir, 'Library', 'LaunchDaemons'),
-        os.path.join(home_dir, 'Library', 'Keychains'),
+        os.path.join(home_dir, ".ssh"),
+        os.path.join(home_dir, ".gnupg"),
+        os.path.join(home_dir, ".config"),
+        os.path.join(home_dir, ".aws"),
+        os.path.join(home_dir, ".claude"),
+        os.path.join(home_dir, "Library", "LaunchAgents"),
+        os.path.join(home_dir, "Library", "LaunchDaemons"),
+        os.path.join(home_dir, "Library", "Keychains"),
     ]
     for sensitive_dir in sensitive_dirs:
-        if resolved_path.startswith(sensitive_dir + os.sep) or resolved_path == sensitive_dir:
+        if (
+            resolved_path.startswith(sensitive_dir + os.sep)
+            or resolved_path == sensitive_dir
+        ):
             return f"Error: Cannot save attachments to sensitive directory: {sensitive_dir}"
 
     expanded_path = resolved_path
@@ -237,10 +252,11 @@ def update_email_status(
     account: str,
     action: str,
     subject_keyword: Optional[str] = None,
+    subject_keywords: Optional[List[str]] = None,
     sender: Optional[str] = None,
     mailbox: str = "INBOX",
     max_updates: int = 10,
-    apply_to_all: bool = False
+    apply_to_all: bool = False,
 ) -> str:
     """
     Update email status - mark as read/unread or flag/unflag emails.
@@ -249,6 +265,7 @@ def update_email_status(
         account: Account name (e.g., "Gmail", "Work")
         action: Action to perform: "mark_read", "mark_unread", "flag", "unflag"
         subject_keyword: Optional keyword to filter emails by subject
+        subject_keywords: Optional list of subject keywords; matches any keyword
         sender: Optional sender to filter emails by
         mailbox: Mailbox to search in (default: "INBOX")
         max_updates: Maximum number of emails to update (safety limit, default: 10)
@@ -258,8 +275,10 @@ def update_email_status(
         Confirmation message with details of updated emails
     """
 
+    subject_terms = normalize_search_terms(subject_keyword, subject_keywords)
+
     # Safety check: require at least one filter or explicit apply_to_all
-    if not subject_keyword and not sender and not apply_to_all:
+    if not subject_terms and not sender and not apply_to_all:
         return (
             "Error: No filter provided. Provide subject_keyword or sender to filter emails, "
             "or set apply_to_all=True to update all messages in the mailbox."
@@ -268,70 +287,206 @@ def update_email_status(
     # Escape all user inputs for AppleScript
     safe_account = escape_applescript(account)
 
-    # Build search condition using helper
-    condition_str = build_filter_condition(subject=subject_keyword, sender=sender)
-
-    # Build action script
+    # Build action and pre-filter so we skip no-op updates.
     if action == "mark_read":
-        action_script = 'set read status of aMessage to true'
+        bulk_action_script = "set read status of targetMessages to true"
+        single_action_script = "set read status of aMessage to true"
+        conditions = ["read status is false"]
         action_label = "Marked as read"
     elif action == "mark_unread":
-        action_script = 'set read status of aMessage to false'
+        bulk_action_script = "set read status of targetMessages to false"
+        single_action_script = "set read status of aMessage to false"
+        conditions = ["read status is true"]
         action_label = "Marked as unread"
     elif action == "flag":
-        action_script = 'set flagged status of aMessage to true'
+        bulk_action_script = "set flagged status of targetMessages to true"
+        single_action_script = "set flagged status of aMessage to true"
+        conditions = ["flagged status is false"]
         action_label = "Flagged"
     elif action == "unflag":
-        action_script = 'set flagged status of aMessage to false'
+        bulk_action_script = "set flagged status of targetMessages to false"
+        single_action_script = "set flagged status of aMessage to false"
+        conditions = ["flagged status is true"]
         action_label = "Unflagged"
     else:
         return f"Error: Invalid action '{action}'. Use: mark_read, mark_unread, flag, unflag"
 
+    if subject_terms:
+        conditions.append(contains_any_condition("subject", subject_terms))
+    if sender:
+        conditions.append(f'sender contains "{escape_applescript(sender)}"')
+
+    search_condition = " and ".join(conditions)
+
     script = f'''
     tell application "Mail"
-        set outputText to "UPDATING EMAIL STATUS: {action_label}" & return & return
-        set updateCount to 0
+        with timeout of 300 seconds
+            set outputText to "UPDATING EMAIL STATUS: {action_label}" & return & return
+            set updateCount to 0
 
-        try
-            set targetAccount to account "{safe_account}"
-            {build_mailbox_ref(mailbox, var_name="targetMailbox")}
+            try
+                set targetAccount to account "{safe_account}"
+                {build_mailbox_ref(mailbox, var_name="targetMailbox")}
 
-            set mailboxMessages to every message of targetMailbox
+                set matchingMessages to every message of targetMailbox whose {search_condition}
+                set matchingCount to count of matchingMessages
 
-            repeat with aMessage in mailboxMessages
-                if updateCount >= {max_updates} then exit repeat
+                if matchingCount is 0 then
+                    set targetMessages to {{}}
+                else if matchingCount > {max_updates} then
+                    set targetMessages to items 1 thru {max_updates} of matchingMessages
+                else
+                    set targetMessages to matchingMessages
+                end if
 
-                try
-                    set messageSubject to subject of aMessage
-                    set messageSender to sender of aMessage
-                    set messageDate to date received of aMessage
+                set updateCount to count of targetMessages
 
-                    -- Apply filter conditions
-                    if {condition_str} then
-                        {action_script}
+                if updateCount > 0 then
+                    try
+                        {bulk_action_script}
+                    on error
+                        repeat with aMessage in targetMessages
+                            {single_action_script}
+                        end repeat
+                    end try
 
-                        set outputText to outputText & "✓ {action_label}: " & messageSubject & return
-                        set outputText to outputText & "   From: " & messageSender & return
-                        set outputText to outputText & "   Date: " & (messageDate as string) & return & return
+                    repeat with aMessage in targetMessages
+                        try
+                            set messageSubject to subject of aMessage
+                            set messageSender to sender of aMessage
+                            set messageDate to date received of aMessage
 
-                        set updateCount to updateCount + 1
-                    end if
-                end try
-            end repeat
+                            set outputText to outputText & "✓ {action_label}: " & messageSubject & return
+                            set outputText to outputText & "   From: " & messageSender & return
+                            set outputText to outputText & "   Date: " & (messageDate as string) & return & return
+                        end try
+                    end repeat
+                end if
 
-            set outputText to outputText & "========================================" & return
-            set outputText to outputText & "TOTAL UPDATED: " & updateCount & " email(s)" & return
-            set outputText to outputText & "========================================" & return
+                set outputText to outputText & "========================================" & return
+                set outputText to outputText & "TOTAL UPDATED: " & updateCount & " email(s)" & return
+                set outputText to outputText & "========================================" & return
 
-        on error errMsg
-            return "Error: " & errMsg
-        end try
+            on error errMsg
+                return "Error: " & errMsg
+            end try
 
-        return outputText
+            return outputText
+        end timeout
     end tell
     '''
 
-    result = run_applescript(script)
+    result = run_applescript(script, timeout=300)
+    return result
+
+
+@mcp.tool()
+@inject_preferences
+def update_email_status_by_ids(
+    account: str,
+    mailbox: str,
+    message_ids: List[str],
+    action: str,
+) -> str:
+    """
+    Update email status using explicit Mail message ids.
+
+    Args:
+        account: Account name (e.g., "Gmail", "Work")
+        mailbox: Mailbox containing the target messages
+        message_ids: Exact Mail message ids returned by JSON search tools
+        action: Action to perform: "mark_read", "mark_unread", "flag", "unflag"
+
+    Returns:
+        Confirmation message with details of updated emails
+    """
+    normalized_ids = normalize_message_ids(message_ids)
+    if not normalized_ids:
+        return "Error: 'message_ids' must contain one or more numeric Mail ids"
+
+    safe_account = escape_applescript(account)
+    safe_mailbox = escape_applescript(mailbox)
+
+    if action == "mark_read":
+        bulk_action_script = "set read status of targetMessages to true"
+        single_action_script = "set read status of aMessage to true"
+        action_label = "Marked as read"
+    elif action == "mark_unread":
+        bulk_action_script = "set read status of targetMessages to false"
+        single_action_script = "set read status of aMessage to false"
+        action_label = "Marked as unread"
+    elif action == "flag":
+        bulk_action_script = "set flagged status of targetMessages to true"
+        single_action_script = "set flagged status of aMessage to true"
+        action_label = "Flagged"
+    elif action == "unflag":
+        bulk_action_script = "set flagged status of targetMessages to false"
+        single_action_script = "set flagged status of aMessage to false"
+        action_label = "Unflagged"
+    else:
+        return f"Error: Invalid action '{action}'. Use: mark_read, mark_unread, flag, unflag"
+
+    id_condition = equals_any_numeric_condition("id", normalized_ids)
+
+    script = f'''
+    tell application "Mail"
+        with timeout of 300 seconds
+            set outputText to "UPDATING EMAIL STATUS BY IDS: {action_label}" & return & return
+            set updateCount to 0
+
+            try
+                set targetAccount to account "{safe_account}"
+                try
+                    set targetMailbox to mailbox "{safe_mailbox}" of targetAccount
+                on error
+                    if "{safe_mailbox}" is "INBOX" then
+                        set targetMailbox to mailbox "Inbox" of targetAccount
+                    else
+                        error "Mailbox not found: {safe_mailbox}"
+                    end if
+                end try
+
+                set targetMessages to every message of targetMailbox whose {id_condition}
+                set requestedCount to {len(normalized_ids)}
+
+                if (count of targetMessages) > 0 then
+                    try
+                        {bulk_action_script}
+                    on error
+                        repeat with aMessage in targetMessages
+                            {single_action_script}
+                        end repeat
+                    end try
+
+                    repeat with aMessage in targetMessages
+                        try
+                            set messageSubject to subject of aMessage
+                            set messageSender to sender of aMessage
+                            set messageDate to date received of aMessage
+
+                            set outputText to outputText & "✓ {action_label}: " & messageSubject & return
+                            set outputText to outputText & "   From: " & messageSender & return
+                            set outputText to outputText & "   Date: " & (messageDate as string) & return & return
+                            set updateCount to updateCount + 1
+                        end try
+                    end repeat
+                end if
+
+                set outputText to outputText & "========================================" & return
+                set outputText to outputText & "REQUESTED IDS: " & requestedCount & return
+                set outputText to outputText & "TOTAL UPDATED: " & updateCount & " email(s)" & return
+                set outputText to outputText & "========================================" & return
+
+            on error errMsg
+                return "Error: " & errMsg
+            end try
+
+            return outputText
+        end timeout
+    end tell
+    '''
+
+    result = run_applescript(script, timeout=300)
     return result
 
 
@@ -341,11 +496,12 @@ def manage_trash(
     account: str,
     action: str,
     subject_keyword: Optional[str] = None,
+    subject_keywords: Optional[List[str]] = None,
     sender: Optional[str] = None,
     mailbox: str = "INBOX",
     max_deletes: int = 5,
     confirm_empty: bool = False,
-    apply_to_all: bool = False
+    apply_to_all: bool = False,
 ) -> str:
     """
     Manage trash operations - delete emails or empty trash.
@@ -354,6 +510,7 @@ def manage_trash(
         account: Account name (e.g., "Gmail", "Work")
         action: Action to perform: "move_to_trash", "delete_permanent", "empty_trash"
         subject_keyword: Optional keyword to filter emails (not used for empty_trash)
+        subject_keywords: Optional list of subject keywords; matches any keyword
         sender: Optional sender to filter emails (not used for empty_trash)
         mailbox: Source mailbox (default: "INBOX", not used for empty_trash or delete_permanent)
         max_deletes: Maximum number of emails to delete (safety limit, default: 5)
@@ -366,6 +523,8 @@ def manage_trash(
 
     # Escape all user inputs for AppleScript
     safe_account = escape_applescript(account)
+    safe_mailbox = escape_applescript(mailbox)
+    subject_terms = normalize_search_terms(subject_keyword, subject_keywords)
 
     if action == "empty_trash":
         if not confirm_empty:
@@ -406,127 +565,161 @@ def manage_trash(
         '''
     elif action == "delete_permanent":
         # Safety check: require at least one filter or explicit apply_to_all
-        if not subject_keyword and not sender and not apply_to_all:
+        if not subject_terms and not sender and not apply_to_all:
             return (
                 "Error: No filter provided. Provide subject_keyword or sender to filter emails, "
                 "or set apply_to_all=True to delete all matching messages."
             )
 
-        condition_str = build_filter_condition(subject=subject_keyword, sender=sender)
+        # Build search condition with escaped inputs
+        conditions = []
+        if subject_terms:
+            conditions.append(contains_any_condition("subject", subject_terms))
+        if sender:
+            conditions.append(f'sender contains "{escape_applescript(sender)}"')
+
+        if conditions:
+            matching_messages_script = f"set matchingMessages to every message of trashMailbox whose {' and '.join(conditions)}"
+        else:
+            matching_messages_script = (
+                "set matchingMessages to every message of trashMailbox"
+            )
 
         script = f'''
         tell application "Mail"
-            set outputText to "PERMANENTLY DELETING EMAILS" & return & return
-            set deleteCount to 0
+            with timeout of 300 seconds
+                set outputText to "PERMANENTLY DELETING EMAILS" & return & return
+                set deleteCount to 0
 
-            try
-                set targetAccount to account "{safe_account}"
-                set trashMailbox to mailbox "Trash" of targetAccount
-                set trashMessages to every message of trashMailbox
+                try
+                    set targetAccount to account "{safe_account}"
+                    set trashMailbox to mailbox "Trash" of targetAccount
+                    {matching_messages_script}
+                    set matchingCount to count of matchingMessages
 
-                repeat with aMessage in trashMessages
-                    if deleteCount >= {max_deletes} then exit repeat
+                    if matchingCount is 0 then
+                        set targetMessages to {{}}
+                    else if matchingCount > {max_deletes} then
+                        set targetMessages to items 1 thru {max_deletes} of matchingMessages
+                    else
+                        set targetMessages to matchingMessages
+                    end if
 
-                    try
-                        set messageSubject to subject of aMessage
-                        set messageSender to sender of aMessage
+                    repeat with aMessage in targetMessages
+                        try
+                            set messageSubject to subject of aMessage
+                            set messageSender to sender of aMessage
 
-                        -- Apply filter conditions
-                        if {condition_str} then
                             set outputText to outputText & "✓ Permanently deleted: " & messageSubject & return
                             set outputText to outputText & "   From: " & messageSender & return & return
 
                             delete aMessage
                             set deleteCount to deleteCount + 1
-                        end if
-                    end try
-                end repeat
+                        end try
+                    end repeat
 
-                set outputText to outputText & "========================================" & return
-                set outputText to outputText & "TOTAL DELETED: " & deleteCount & " email(s)" & return
-                set outputText to outputText & "========================================" & return
+                    set outputText to outputText & "========================================" & return
+                    set outputText to outputText & "TOTAL DELETED: " & deleteCount & " email(s)" & return
+                    set outputText to outputText & "========================================" & return
 
-            on error errMsg
-                return "Error: " & errMsg
-            end try
+                on error errMsg
+                    return "Error: " & errMsg
+                end try
 
-            return outputText
+                return outputText
+            end timeout
         end tell
         '''
     else:  # move_to_trash
         # Safety check: require at least one filter or explicit apply_to_all
-        if not subject_keyword and not sender and not apply_to_all:
+        if not subject_terms and not sender and not apply_to_all:
             return (
                 "Error: No filter provided. Provide subject_keyword or sender to filter emails, "
                 "or set apply_to_all=True to move all messages to trash."
             )
 
-        condition_str = build_filter_condition(subject=subject_keyword, sender=sender)
-        safe_mailbox = escape_applescript(mailbox)
+        # Build search condition with escaped inputs
+        conditions = []
+        if subject_terms:
+            conditions.append(contains_any_condition("subject", subject_terms))
+        if sender:
+            conditions.append(f'sender contains "{escape_applescript(sender)}"')
+
+        if conditions:
+            matching_messages_script = f"set matchingMessages to every message of sourceMailbox whose {' and '.join(conditions)}"
+        else:
+            matching_messages_script = (
+                "set matchingMessages to every message of sourceMailbox"
+            )
 
         script = f'''
         tell application "Mail"
-            set outputText to "MOVING EMAILS TO TRASH" & return & return
-            set deleteCount to 0
+            with timeout of 300 seconds
+                set outputText to "MOVING EMAILS TO TRASH" & return & return
+                set deleteCount to 0
 
-            try
-                set targetAccount to account "{safe_account}"
-                -- Get source mailbox
                 try
-                    set sourceMailbox to mailbox "{safe_mailbox}" of targetAccount
-                on error
-                    if "{safe_mailbox}" is "INBOX" then
-                        set sourceMailbox to mailbox "Inbox" of targetAccount
-                    else
-                        error "Mailbox not found: {safe_mailbox}"
-                    end if
-                end try
-
-                -- Get trash mailbox
-                set trashMailbox to mailbox "Trash" of targetAccount
-                set sourceMessages to every message of sourceMailbox
-
-                repeat with aMessage in sourceMessages
-                    if deleteCount >= {max_deletes} then exit repeat
-
+                    set targetAccount to account "{safe_account}"
+                    -- Get source mailbox
                     try
-                        set messageSubject to subject of aMessage
-                        set messageSender to sender of aMessage
-                        set messageDate to date received of aMessage
+                        set sourceMailbox to mailbox "{safe_mailbox}" of targetAccount
+                    on error
+                        if "{safe_mailbox}" is "INBOX" then
+                            set sourceMailbox to mailbox "Inbox" of targetAccount
+                        else
+                            error "Mailbox not found: {safe_mailbox}"
+                        end if
+                    end try
 
-                        -- Apply filter conditions
-                        if {condition_str} then
+                    -- Get trash mailbox
+                    set trashMailbox to mailbox "Trash" of targetAccount
+                    {matching_messages_script}
+                    set matchingCount to count of matchingMessages
+
+                    if matchingCount is 0 then
+                        set targetMessages to {{}}
+                    else if matchingCount > {max_deletes} then
+                        set targetMessages to items 1 thru {max_deletes} of matchingMessages
+                    else
+                        set targetMessages to matchingMessages
+                    end if
+
+                    repeat with aMessage in targetMessages
+                        try
+                            set messageSubject to subject of aMessage
+                            set messageSender to sender of aMessage
+                            set messageDate to date received of aMessage
+
                             move aMessage to trashMailbox
+                            set deleteCount to deleteCount + 1
 
                             set outputText to outputText & "✓ Moved to trash: " & messageSubject & return
                             set outputText to outputText & "   From: " & messageSender & return
                             set outputText to outputText & "   Date: " & (messageDate as string) & return & return
+                        end try
+                    end repeat
 
-                            set deleteCount to deleteCount + 1
-                        end if
-                    end try
-                end repeat
+                    set outputText to outputText & "========================================" & return
+                    set outputText to outputText & "TOTAL MOVED TO TRASH: " & deleteCount & " email(s)" & return
+                    set outputText to outputText & "========================================" & return
 
-                set outputText to outputText & "========================================" & return
-                set outputText to outputText & "TOTAL MOVED TO TRASH: " & deleteCount & " email(s)" & return
-                set outputText to outputText & "========================================" & return
+                on error errMsg
+                    return "Error: " & errMsg
+                end try
 
-            on error errMsg
-                return "Error: " & errMsg
-            end try
-
-            return outputText
+                return outputText
+            end timeout
         end tell
         '''
 
-    result = run_applescript(script)
+    result = run_applescript(script, timeout=300)
     return result
 
 
 import re
 
 # Characters that could break AppleScript strings or mailbox names
-_INVALID_MAILBOX_CHARS = re.compile(r'[\\\"<>|?*:\x00-\x1f]')
+_INVALID_MAILBOX_CHARS = re.compile(r"[\\\"<>|?*:\x00-\x1f]")
 
 
 @mcp.tool()
@@ -566,7 +759,7 @@ def create_mailbox(
         if _INVALID_MAILBOX_CHARS.search(seg):
             return (
                 f"Error: Invalid characters in mailbox name segment '{seg}'. "
-                "Avoid \\ \" < > | ? * : and control characters."
+                'Avoid \\ " < > | ? * : and control characters.'
             )
 
     safe_account = escape_applescript(account)
@@ -675,13 +868,15 @@ def archive_emails(
     condition_str = build_filter_condition(subject=subject_keyword, sender=sender)
     if only_read:
         read_cond = "messageRead is true"
-        condition_str = f"{condition_str} and {read_cond}" if condition_str != "true" else read_cond
+        condition_str = (
+            f"{condition_str} and {read_cond}" if condition_str != "true" else read_cond
+        )
 
     # Date filter
     date_setup = ""
     date_cond = ""
     if older_than_days and older_than_days > 0:
-        date_setup = f'set cutoffDate to (current date) - ({older_than_days} * days)'
+        date_setup = f"set cutoffDate to (current date) - ({older_than_days} * days)"
         date_cond = " and messageDate < cutoffDate"
 
     if dry_run:

--- a/apple_mail_mcp/tools/search.py
+++ b/apple_mail_mcp/tools/search.py
@@ -1,422 +1,1673 @@
 """Search tools: finding and filtering emails."""
 
 import json
+import re
+from datetime import datetime
 from typing import Optional, List, Dict, Any
+from urllib.parse import quote
 
 from apple_mail_mcp.server import mcp
 from apple_mail_mcp.core import (
+    contains_any_condition,
     inject_preferences,
     escape_applescript,
+    normalize_search_terms,
     run_applescript,
     LOWERCASE_HANDLER,
-    build_mailbox_ref,
-    skip_folders_condition,
-)
-from apple_mail_mcp.constants import (
-    SKIP_FOLDERS,
-    NEWSLETTER_PLATFORM_PATTERNS,
-    NEWSLETTER_KEYWORD_PATTERNS,
-    THREAD_PREFIXES,
 )
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers for building AppleScript fragments
-# ---------------------------------------------------------------------------
-
-def _build_whose_clause(
-    subject: Optional[str],
-    sender: Optional[str],
-    body: Optional[str],
-    is_read: Optional[bool],
-    date_from: Optional[str],
-    date_to: Optional[str],
-) -> tuple[str, list[str]]:
-    """Build a `whose` clause for fast Mail.app-level filtering.
-
-    Returns (date_setup_script, list_of_conditions).
-    The caller joins conditions with ' and ' and wraps in `whose ...`.
-
-    Note: AppleScript's `contains` is case-insensitive by default,
-    so body/subject/sender filters don't need a lowercase handler.
-    """
-    conditions: list[str] = []
-    date_setup = ""
-
-    if subject:
-        conditions.append(f'subject contains "{escape_applescript(subject)}"')
-    if sender:
-        conditions.append(f'sender contains "{escape_applescript(sender)}"')
-    if body:
-        conditions.append(f'content contains "{escape_applescript(body)}"')
-    if is_read is True:
-        conditions.append("read status is true")
-    elif is_read is False:
-        conditions.append("read status is false")
-
-    if date_from:
-        y, m, d = date_from.split("-")
-        date_setup += f"""
-            set dateFrom to current date
-            set year of dateFrom to {int(y)}
-            set month of dateFrom to {int(m)}
-            set day of dateFrom to {int(d)}
-            set time of dateFrom to 0
-        """
-        conditions.append("date received >= dateFrom")
-
-    if date_to:
-        y, m, d = date_to.split("-")
-        date_setup += f"""
-            set dateTo to current date
-            set year of dateTo to {int(y)}
-            set month of dateTo to {int(m)}
-            set day of dateTo to {int(d)}
-            set time of dateTo to 86399
-        """
-        conditions.append("date received <= dateTo")
-
-    return date_setup, conditions
+MONTH_NAMES = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+]
 
 
-def _build_post_filters(
-    has_attachments: Optional[bool],
-    is_flagged: Optional[bool],
-    is_newsletter: bool,
-) -> tuple[bool, str]:
-    """Build loop-level post-filter checks (things `whose` can't handle).
+def _build_applescript_date(
+    var_name: str, date_value: Optional[str], end_of_day: bool = False
+) -> str:
+    """Build AppleScript to create a date from an ISO day string."""
+    if not date_value:
+        return ""
 
-    Returns (needs_lowercase_handler, applescript_filter_block).
-    The block sets `skipMsg` to true when the message should be excluded.
+    try:
+        parsed_date = datetime.strptime(date_value, "%Y-%m-%d")
+    except ValueError:
+        raise ValueError(f"Invalid date '{date_value}'. Use YYYY-MM-DD")
 
-    Note: body search is handled by the `whose` clause (native Mail.app
-    filtering) for much better performance — not done here.
-    """
-    lines: list[str] = []
-    needs_lowercase = False
-
-    if has_attachments is True:
-        lines.append("if (count of mail attachments of aMessage) = 0 then set skipMsg to true")
-    elif has_attachments is False:
-        lines.append("if (count of mail attachments of aMessage) > 0 then set skipMsg to true")
-
-    if is_flagged is True:
-        lines.append("if not (flagged status of aMessage) then set skipMsg to true")
-    elif is_flagged is False:
-        lines.append("if (flagged status of aMessage) then set skipMsg to true")
-
-    if is_newsletter:
-        needs_lowercase = True
-        # Build the newsletter sender check
-        platform_checks = " or ".join(
-            f'lowerSender contains "{p}"' for p in NEWSLETTER_PLATFORM_PATTERNS
-        )
-        keyword_checks = " or ".join(
-            f'lowerSender contains "{p}"' for p in NEWSLETTER_KEYWORD_PATTERNS
-        )
-        lines.append(f"""
-                                set lowerSender to my lowercase(messageSender)
-                                set isNL to false
-                                if {platform_checks} then set isNL to true
-                                if {keyword_checks} then set isNL to true
-                                if not isNL then set skipMsg to true
-        """)
-
-    block = "\n                                ".join(lines)
-    return needs_lowercase, block
-
-
-def _build_content_script(max_content_length: int) -> str:
-    """AppleScript snippet to extract content preview into outputText."""
+    month_name = MONTH_NAMES[parsed_date.month - 1]
+    seconds = 86399 if end_of_day else 0
     return f"""
-                                try
-                                    set msgContent to content of aMessage
-                                    set AppleScript's text item delimiters to {{return, linefeed}}
-                                    set contentParts to text items of msgContent
-                                    set AppleScript's text item delimiters to " "
-                                    set cleanText to contentParts as string
-                                    set AppleScript's text item delimiters to ""
-                                    if length of cleanText > {max_content_length} then
-                                        set contentPreview to text 1 thru {max_content_length} of cleanText & "..."
-                                    else
-                                        set contentPreview to cleanText
-                                    end if
-                                on error
-                                    set contentPreview to "[Not available]"
-                                end try
+                set {var_name} to current date
+                set year of {var_name} to {parsed_date.year}
+                set month of {var_name} to {month_name}
+                set day of {var_name} to {parsed_date.day}
+                set time of {var_name} to {seconds}
     """
 
 
-def _parse_pipe_output(raw: str) -> list[dict[str, Any]]:
-    """Parse pipe-delimited AppleScript output into list of dicts."""
-    emails: list[dict[str, Any]] = []
-    if not raw:
-        return emails
-    for line in raw.split("\n"):
-        if "|||" not in line:
+def _parse_search_records(output: str) -> List[Dict[str, Any]]:
+    """Parse structured search output into dict records."""
+    if not output:
+        return []
+
+    records = []
+    for line in output.splitlines():
+        parts = line.split("|||", 8)
+        if len(parts) < 8:
             continue
-        parts = line.split("|||")
-        if len(parts) >= 6:
-            emails.append({
-                "subject": parts[0].strip(),
-                "sender": parts[1].strip(),
-                "date": parts[2].strip(),
-                "is_read": parts[3].strip().lower() == "true",
-                "account": parts[4].strip(),
-                "mailbox": parts[5].strip(),
-                "content": parts[6].strip() if len(parts) > 6 else "",
-            })
-    return emails
+
+        internet_message_id = parts[1].strip()
+        record = {
+            "message_id": parts[0].strip(),
+            "internet_message_id": internet_message_id,
+            "subject": parts[2].strip(),
+            "sender": parts[3].strip(),
+            "mailbox": parts[4].strip(),
+            "account": parts[5].strip(),
+            "is_read": parts[6].strip().lower() == "true",
+            "received_date": parts[7].strip(),
+        }
+        if internet_message_id:
+            record["mail_link"] = "message:" + quote(internet_message_id, safe="")
+        if len(parts) > 8 and parts[8].strip():
+            record["content_preview"] = parts[8].strip()
+        records.append(record)
+
+    return records
 
 
-# ---------------------------------------------------------------------------
-# The single consolidated search tool
-# ---------------------------------------------------------------------------
+def _sort_search_records(
+    records: List[Dict[str, Any]], sort: str
+) -> List[Dict[str, Any]]:
+    """Sort records by received date."""
+    reverse = sort == "date_desc"
+    return sorted(
+        records, key=lambda item: item.get("received_date", ""), reverse=reverse
+    )
+
+
+def _format_search_records_text(
+    records: List[Dict[str, Any]],
+    subject_only: bool = False,
+) -> str:
+    """Format search records as human-readable text."""
+    lines = []
+
+    if subject_only:
+        lines.append("SUBJECT SEARCH RESULTS")
+        lines.append("")
+        for item in records:
+            lines.append(f"- {item['subject']}")
+    else:
+        lines.append("SEARCH RESULTS")
+        lines.append("")
+        for item in records:
+            indicator = "✓" if item["is_read"] else "✉"
+            lines.append(f"{indicator} {item['subject']}")
+            lines.append(f"   From: {item['sender']}")
+            lines.append(f"   Date: {item['received_date']}")
+            lines.append(f"   Mailbox: {item['mailbox']}")
+            if item.get("content_preview"):
+                lines.append(f"   Content: {item['content_preview']}")
+            lines.append("")
+
+    lines.append("========================================")
+    lines.append(f"FOUND: {len(records)} matching email(s)")
+    lines.append("========================================")
+    return "\n".join(lines)
+
+
+def _build_search_response(
+    records: List[Dict[str, Any]],
+    offset: int,
+    limit: int,
+    sort: str,
+    output_format: str,
+    subject_only: bool = False,
+) -> str:
+    """Return either JSON or text for search results."""
+    sorted_records = _sort_search_records(records, sort)
+    has_more = len(sorted_records) > limit
+    items = sorted_records[:limit]
+    next_offset = offset + len(items) if has_more else None
+
+    if output_format == "json":
+        return json.dumps(
+            {
+                "items": items,
+                "offset": offset,
+                "limit": limit,
+                "returned": len(items),
+                "has_more": has_more,
+                "next_offset": next_offset,
+                "sort": sort,
+            }
+        )
+
+    return _format_search_records_text(items, subject_only=subject_only)
+
+
+def _search_mail_records(
+    account: str,
+    mailbox: str,
+    subject_terms: Optional[List[str]] = None,
+    sender: Optional[str] = None,
+    has_attachments: Optional[bool] = None,
+    read_status: str = "all",
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    include_content: bool = False,
+    content_length: int = 300,
+    offset: int = 0,
+    limit: int = 100,
+    sort: str = "date_desc",
+) -> List[Dict[str, Any]]:
+    """Return structured search records from Apple Mail."""
+    if offset < 0:
+        raise ValueError("offset must be >= 0")
+    if limit <= 0:
+        return []
+    if sort not in {"date_desc", "date_asc"}:
+        raise ValueError("Invalid sort. Use: date_desc, date_asc")
+    if read_status not in {"all", "read", "unread"}:
+        raise ValueError("Invalid read_status. Use: all, read, unread")
+
+    escaped_account = escape_applescript(account)
+    escaped_mailbox = escape_applescript(mailbox)
+    escaped_sender = escape_applescript(sender) if sender else None
+
+    filter_conditions = []
+    if subject_terms:
+        filter_conditions.append(contains_any_condition("subject", subject_terms))
+    if sender:
+        filter_conditions.append(f'sender contains "{escaped_sender}"')
+    if has_attachments is not None:
+        if has_attachments:
+            filter_conditions.append("(count of mail attachments) > 0")
+        else:
+            filter_conditions.append("(count of mail attachments) = 0")
+    if read_status == "read":
+        filter_conditions.append("read status is true")
+    elif read_status == "unread":
+        filter_conditions.append("read status is false")
+    if date_from:
+        filter_conditions.append("date received >= fromDate")
+    if date_to:
+        filter_conditions.append("date received <= toDate")
+
+    if filter_conditions:
+        matching_messages_script = f"set matchingMessages to every message of currentMailbox whose {' and '.join(filter_conditions)}"
+    else:
+        matching_messages_script = (
+            "set matchingMessages to every message of currentMailbox"
+        )
+
+    if mailbox == "All":
+        mailbox_script = """
+                set searchMailboxes to every mailbox of targetAccount
+        """
+        skip_script = """
+                        set skipFolders to {"Trash", "Junk", "Junk Email", "Deleted Items", "Sent", "Sent Items", "Sent Messages", "Drafts", "Spam", "Deleted Messages"}
+                        repeat with skipFolder in skipFolders
+                            if mailboxName is skipFolder then
+                                set shouldSkip to true
+                                exit repeat
+                            end if
+                        end repeat
+        """
+    else:
+        mailbox_script = f'''
+                try
+                    set searchMailbox to mailbox "{escaped_mailbox}" of targetAccount
+                on error
+                    if "{escaped_mailbox}" is "INBOX" then
+                        set searchMailbox to mailbox "Inbox" of targetAccount
+                    else
+                        error "Mailbox not found: {escaped_mailbox}"
+                    end if
+                end try
+                set searchMailboxes to {{searchMailbox}}
+        '''
+        skip_script = ""
+
+    date_setup = _build_applescript_date("fromDate", date_from)
+    date_setup += _build_applescript_date("toDate", date_to, end_of_day=True)
+
+    script = f'''
+    on sanitize_field(value)
+        try
+            set valueText to value as string
+        on error
+            set valueText to ""
+        end try
+
+        set AppleScript's text item delimiters to {{return, linefeed, tab}}
+        set valueParts to text items of valueText
+        set AppleScript's text item delimiters to " "
+        set valueText to valueParts as string
+        set AppleScript's text item delimiters to "|||"
+        set valueParts to text items of valueText
+        set AppleScript's text item delimiters to " | "
+        set valueText to valueParts as string
+        set AppleScript's text item delimiters to ""
+        return valueText
+    end sanitize_field
+
+    on pad2(numberValue)
+        if numberValue < 10 then
+            return "0" & (numberValue as string)
+        end if
+        return numberValue as string
+    end pad2
+
+    on month_number(monthValue)
+        set monthValues to {{January, February, March, April, May, June, July, August, September, October, November, December}}
+        repeat with monthIndex from 1 to 12
+            if item monthIndex of monthValues is monthValue then
+                return monthIndex
+            end if
+        end repeat
+        return 0
+    end month_number
+
+    on iso_datetime(dateValue)
+        set yearValue to year of dateValue as integer
+        set monthValue to my month_number(month of dateValue)
+        set dayValue to day of dateValue as integer
+        set hourValue to hours of dateValue
+        set minuteValue to minutes of dateValue
+        set secondValue to seconds of dateValue
+        return (yearValue as string) & "-" & my pad2(monthValue) & "-" & my pad2(dayValue) & "T" & my pad2(hourValue) & ":" & my pad2(minuteValue) & ":" & my pad2(secondValue)
+    end iso_datetime
+
+    tell application "Mail"
+        with timeout of 180 seconds
+            try
+                set recordLines to {{}}
+                set offsetRemaining to {offset}
+                set collectLimit to {limit + 1}
+                set targetAccount to account "{escaped_account}"
+                set accountName to my sanitize_field(name of targetAccount)
+                {date_setup}
+                {mailbox_script}
+
+                repeat with currentMailbox in searchMailboxes
+                    if collectLimit <= 0 then exit repeat
+
+                    try
+                        set mailboxName to my sanitize_field(name of currentMailbox)
+                        set shouldSkip to false
+                        {skip_script}
+
+                        if not shouldSkip then
+                            {matching_messages_script}
+                            set matchingCount to count of matchingMessages
+
+                            if offsetRemaining >= matchingCount then
+                                set offsetRemaining to offsetRemaining - matchingCount
+                            else
+                                set startIndex to offsetRemaining + 1
+                                set availableCount to matchingCount - offsetRemaining
+                                if availableCount > collectLimit then
+                                    set endIndex to startIndex + collectLimit - 1
+                                else
+                                    set endIndex to startIndex + availableCount - 1
+                                end if
+
+                                if endIndex >= startIndex then
+                                    set targetMessages to items startIndex thru endIndex of matchingMessages
+
+                                    repeat with aMessage in targetMessages
+                                        try
+                                            set messageId to my sanitize_field(id of aMessage)
+                                            set internetMessageId to ""
+                                            try
+                                                set internetMessageId to my sanitize_field(message id of aMessage)
+                                            end try
+                                            set messageSubject to my sanitize_field(subject of aMessage)
+                                            set messageSender to my sanitize_field(sender of aMessage)
+                                            set messageRead to read status of aMessage
+                                            set messageDate to date received of aMessage
+                                            set receivedAt to my iso_datetime(messageDate)
+                                            set contentPreview to ""
+
+                                            if {str(include_content).lower()} then
+                                                try
+                                                    set msgContent to content of aMessage
+                                                    set AppleScript's text item delimiters to {{return, linefeed, tab}}
+                                                    set contentParts to text items of msgContent
+                                                    set AppleScript's text item delimiters to " "
+                                                    set cleanText to contentParts as string
+                                                    set AppleScript's text item delimiters to ""
+                                                    if {content_length} > 0 and length of cleanText > {content_length} then
+                                                        set contentPreview to my sanitize_field(text 1 thru {content_length} of cleanText & "...")
+                                                    else
+                                                        set contentPreview to my sanitize_field(cleanText)
+                                                    end if
+                                                on error
+                                                    set contentPreview to ""
+                                                end try
+                                            end if
+
+                                            set readValue to "false"
+                                            if messageRead then
+                                                set readValue to "true"
+                                            end if
+
+                                            set recordLine to messageId & "|||" & internetMessageId & "|||" & messageSubject & "|||" & messageSender & "|||" & mailboxName & "|||" & accountName & "|||" & readValue & "|||" & receivedAt & "|||" & contentPreview
+                                            set end of recordLines to recordLine
+                                            set collectLimit to collectLimit - 1
+                                            if collectLimit <= 0 then exit repeat
+                                        end try
+                                    end repeat
+                                end if
+
+                                set offsetRemaining to 0
+                            end if
+                        end if
+                    on error
+                        -- Skip mailboxes that cannot be searched
+                    end try
+                end repeat
+
+                if (count of recordLines) is 0 then
+                    return ""
+                end if
+
+                set AppleScript's text item delimiters to linefeed
+                set outputText to recordLines as string
+                set AppleScript's text item delimiters to ""
+                return outputText
+            on error errMsg
+                return "ERROR|||" & errMsg
+            end try
+        end timeout
+    end tell
+    '''
+
+    result = run_applescript(script, timeout=180)
+    if result.startswith("ERROR|||"):
+        raise ValueError(result.split("|||", 1)[1])
+
+    return _parse_search_records(result)
+
+
+@mcp.tool()
+@inject_preferences
+def search_subjects(
+    account: str,
+    subject_keyword: Optional[str] = None,
+    mailbox: str = "INBOX",
+    max_results: Optional[int] = 25,
+    subject_keywords: Optional[List[str]] = None,
+    read_status: str = "all",
+    output_format: str = "text",
+    offset: int = 0,
+    limit: Optional[int] = None,
+    sort: str = "date_desc",
+) -> str:
+    """
+    Search for emails by subject and return matching subjects or structured JSON.
+
+    Args:
+        account: Account name to search in (e.g., "Gmail", "Work")
+        subject_keyword: Optional keyword to search for in email subjects
+        mailbox: Mailbox to search (default: "INBOX", use "All" for all mailboxes)
+        max_results: Backward-compatible alias for limit
+        subject_keywords: Optional list of subject keywords; matches any keyword
+        read_status: Filter by read status: "all", "read", "unread" (default: "all")
+        output_format: Output format: "text" or "json" (default: "text")
+        offset: Number of matching results to skip before returning data
+        limit: Maximum number of results to return per page
+        sort: Result sort order: "date_desc" or "date_asc"
+
+    Returns:
+        Formatted subject list or JSON payload with message metadata
+    """
+    if output_format not in {"text", "json"}:
+        return "Error: Invalid output_format. Use: text, json"
+
+    subject_terms = normalize_search_terms(subject_keyword, subject_keywords)
+    if not subject_terms:
+        return "Error: 'subject_keyword' or 'subject_keywords' is required"
+
+    if limit is None:
+        limit = max_results if max_results is not None else 25
+
+    try:
+        records = _search_mail_records(
+            account=account,
+            mailbox=mailbox,
+            subject_terms=subject_terms,
+            read_status=read_status,
+            include_content=False,
+            offset=offset,
+            limit=limit,
+            sort=sort,
+        )
+        return _build_search_response(
+            records,
+            offset=offset,
+            limit=limit,
+            sort=sort,
+            output_format=output_format,
+            subject_only=True,
+        )
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+
+@mcp.tool()
+@inject_preferences
+def get_email_with_content(
+    account: str,
+    subject_keyword: str,
+    max_results: int = 5,
+    max_content_length: int = 300,
+    mailbox: str = "INBOX",
+) -> str:
+    """
+    Search for emails by subject keyword and return with full content preview.
+
+    Args:
+        account: Account name to search in (e.g., "Gmail", "Work")
+        subject_keyword: Keyword to search for in email subjects
+        max_results: Maximum number of matching emails to return (default: 5)
+        max_content_length: Maximum content length in characters (default: 300, 0 = unlimited)
+        mailbox: Mailbox to search (default: "INBOX", use "All" for all mailboxes)
+
+    Returns:
+        Detailed email information including content preview
+    """
+    try:
+        records = _search_mail_records(
+            account=account,
+            mailbox=mailbox,
+            subject_terms=normalize_search_terms(subject_keyword),
+            include_content=True,
+            content_length=max_content_length,
+            offset=0,
+            limit=max_results,
+            sort="date_desc",
+        )
+        return _build_search_response(
+            records,
+            offset=0,
+            limit=max_results,
+            sort="date_desc",
+            output_format="text",
+            subject_only=False,
+        )
+    except ValueError as exc:
+        return f"Error: {exc}"
+
 
 @mcp.tool()
 @inject_preferences
 def search_emails(
-    account: Optional[str] = None,
+    account: str,
     mailbox: str = "INBOX",
-    subject: Optional[str] = None,
+    subject_keyword: Optional[str] = None,
+    subject_keywords: Optional[List[str]] = None,
     sender: Optional[str] = None,
-    body: Optional[str] = None,
+    has_attachments: Optional[bool] = None,
+    read_status: str = "all",
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
-    is_read: Optional[bool] = None,
-    has_attachments: Optional[bool] = None,
-    is_flagged: Optional[bool] = None,
-    is_newsletter: bool = False,
-    is_thread: bool = False,
     include_content: bool = False,
-    max_content_length: int = 500,
-    max_results: int = 25,
+    max_results: Optional[int] = 20,
     output_format: str = "text",
+    offset: int = 0,
+    limit: Optional[int] = None,
+    sort: str = "date_desc",
 ) -> str:
     """
-    Search emails with flexible filters across accounts and mailboxes.
-
-    Replaces all previous search tools with one unified interface.
-    Uses fast native Mail.app filtering for subject, sender, date, and read status.
-    Falls back to slower loop filtering only for body, attachments, flagged, and newsletter detection.
+    Unified search tool with JSON output, pagination, and real date filtering.
 
     Args:
-        account: Account name (e.g. "Gmail", "Work"). None = search all accounts.
-        mailbox: Mailbox to search (default "INBOX", "All" = all mailboxes, or specific folder name like "Archive")
-        subject: Filter by subject keyword (case-insensitive, fast native filter)
-        sender: Filter by sender name or email (case-insensitive, fast native filter)
-        body: Filter by body text content (case-insensitive, slower — requires reading each email body)
-        date_from: Start date inclusive, format "YYYY-MM-DD" (fast native filter)
-        date_to: End date inclusive, format "YYYY-MM-DD" (fast native filter)
-        is_read: Filter by read status: True = read only, False = unread only, None = any
-        has_attachments: True = with attachments only, False = without, None = any
-        is_flagged: True = flagged only, False = unflagged, None = any
-        is_newsletter: When True, only return emails from known newsletter senders (Substack, Beehiiv, Mailchimp, etc.)
-        is_thread: When True, treat 'subject' as a thread topic — strips Re:/Fwd: prefixes and returns full content for conversation view
-        include_content: Include email body preview in results (default False, auto-enabled when is_thread=True)
-        max_content_length: Maximum body preview length in characters (default 500)
-        max_results: Maximum results to return (default 25)
-        output_format: "text" for human-readable output, "json" for structured data
+        account: Account name to search in (e.g., "Gmail", "Work")
+        mailbox: Mailbox to search (default: "INBOX", use "All" for all mailboxes, or specific folder name)
+        subject_keyword: Optional keyword to search in subject
+        subject_keywords: Optional list of subject keywords; matches any keyword
+        sender: Optional sender email or name to filter by
+        has_attachments: Optional filter for emails with attachments (True/False/None)
+        read_status: Filter by read status: "all", "read", "unread" (default: "all")
+        date_from: Optional start date filter (format: "YYYY-MM-DD")
+        date_to: Optional end date filter (format: "YYYY-MM-DD")
+        include_content: Whether to include email content preview (slower)
+        max_results: Backward-compatible alias for limit
+        output_format: Output format: "text" or "json" (default: "text")
+        offset: Number of matching results to skip before returning data
+        limit: Maximum number of results to return per page
+        sort: Result sort order: "date_desc" or "date_asc"
 
     Returns:
-        Matching emails formatted as text or JSON
+        Formatted list of matching emails or JSON payload with stable message metadata
+    """
+    if output_format not in {"text", "json"}:
+        return "Error: Invalid output_format. Use: text, json"
+
+    if limit is None:
+        limit = max_results if max_results is not None else 100
+
+    subject_terms = normalize_search_terms(subject_keyword, subject_keywords)
+
+    try:
+        records = _search_mail_records(
+            account=account,
+            mailbox=mailbox,
+            subject_terms=subject_terms,
+            sender=sender,
+            has_attachments=has_attachments,
+            read_status=read_status,
+            date_from=date_from,
+            date_to=date_to,
+            include_content=include_content,
+            offset=offset,
+            limit=limit,
+            sort=sort,
+        )
+        return _build_search_response(
+            records,
+            offset=offset,
+            limit=limit,
+            sort=sort,
+            output_format=output_format,
+            subject_only=False,
+        )
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+
+@mcp.tool()
+@inject_preferences
+def group_emails_by_subject_regex(
+    account: str,
+    mailbox: str = "INBOX",
+    read_status: str = "unread",
+    regex: str = "",
+    offset: int = 0,
+    limit: int = 200,
+    sort: str = "date_desc",
+) -> str:
+    """
+    Group email subjects by a regex key and return grouped JSON.
+
+    Args:
+        account: Account name to search in
+        mailbox: Mailbox to scan (default: "INBOX")
+        read_status: Filter by read status: "all", "read", "unread" (default: "unread")
+        regex: Regex used to extract a grouping key from the subject
+        offset: Number of matching results to skip before grouping
+        limit: Maximum number of emails to scan for grouping
+        sort: Result sort order before grouping: "date_desc" or "date_asc"
+
+    Returns:
+        JSON payload grouped by extracted regex key
+    """
+    if not regex:
+        return "Error: 'regex' is required"
+
+    try:
+        pattern = re.compile(regex)
+    except re.error as exc:
+        return f"Error: Invalid regex - {exc}"
+
+    try:
+        records = _search_mail_records(
+            account=account,
+            mailbox=mailbox,
+            read_status=read_status,
+            include_content=False,
+            offset=offset,
+            limit=limit,
+            sort=sort,
+        )
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+    sorted_records = _sort_search_records(records, sort)[:limit]
+    groups: Dict[str, Dict[str, Any]] = {}
+
+    for item in sorted_records:
+        match = pattern.search(item["subject"])
+        if not match:
+            continue
+
+        if match.lastindex:
+            key = next((group for group in match.groups() if group), match.group(0))
+        else:
+            key = match.group(0)
+
+        group = groups.setdefault(
+            key,
+            {
+                "key": key,
+                "count": 0,
+                "message_ids": [],
+                "internet_message_ids": [],
+                "mail_links": [],
+                "subjects": [],
+            },
+        )
+        group["count"] += 1
+        group["message_ids"].append(item["message_id"])
+        if item.get("internet_message_id"):
+            group["internet_message_ids"].append(item["internet_message_id"])
+        if item.get("mail_link"):
+            group["mail_links"].append(item["mail_link"])
+        group["subjects"].append(item["subject"])
+
+    grouped_items = sorted(
+        groups.values(), key=lambda item: (-item["count"], item["key"])
+    )
+    return json.dumps(
+        {
+            "groups": grouped_items,
+            "offset": offset,
+            "limit": limit,
+            "returned_groups": len(grouped_items),
+            "regex": regex,
+            "read_status": read_status,
+            "mailbox": mailbox,
+            "account": account,
+        }
+    )
+
+
+@mcp.tool()
+@inject_preferences
+def search_by_sender(
+    sender: str,
+    account: Optional[str] = None,
+    days_back: int = 30,
+    max_results: int = 20,
+    include_content: bool = True,
+    max_content_length: int = 500,
+    mailbox: str = "INBOX",
+) -> str:
+    """
+    Find all emails from a specific sender across one or all accounts.
+    Perfect for tracking newsletters, contacts, or communications from specific people/organizations.
+
+    Args:
+        sender: Sender name or email to search for (partial match, e.g., "alphasignal" or "john@")
+        account: Optional account name. If None, searches all accounts.
+        days_back: Only search emails from the last N days (default: 30, 0 = all time)
+        max_results: Maximum number of emails to return (default: 20)
+        include_content: Whether to include email content preview (default: True)
+        max_content_length: Maximum length of content preview (default: 500)
+        mailbox: Mailbox to search (default: "INBOX", use "All" for all mailboxes)
+
+    Returns:
+        Formatted list of emails from the sender, sorted by date (newest first)
     """
 
-    # Thread mode: clean subject and force content on
-    if is_thread and subject:
-        for prefix in THREAD_PREFIXES:
-            subject = subject.replace(prefix, "").strip()
-        include_content = True
+    # Build date filter if days_back > 0
+    date_filter_script = ""
+    date_check = ""
+    if days_back > 0:
+        date_filter_script = f"""
+            set targetDate to (current date) - ({days_back} * days)
+        """
+        date_check = "and messageDate > targetDate"
 
-    # Newsletter mode: default to INBOX only, last 7 days if no date set
-    if is_newsletter and not date_from and not date_to:
-        # Default to last 7 days for newsletter detection performance
-        import datetime
-        week_ago = datetime.date.today() - datetime.timedelta(days=7)
-        date_from = week_ago.isoformat()
-
-    # Build the fast `whose` clause (includes body search for native filtering)
-    date_setup, whose_conditions = _build_whose_clause(
-        subject=subject,
-        sender=sender,
-        body=body,
-        is_read=is_read,
-        date_from=date_from,
-        date_to=date_to,
-    )
-
-    if whose_conditions:
-        whose_clause = "whose " + " and ".join(whose_conditions)
-    else:
-        whose_clause = ""
-
-    fetch_script = f"set matchedMessages to (every message of aMailbox {whose_clause})"
-
-    # Build post-filters (slower, loop-level — only for things whose can't handle)
-    needs_lowercase, post_filter_block = _build_post_filters(
-        has_attachments=has_attachments,
-        is_flagged=is_flagged,
-        is_newsletter=is_newsletter,
-    )
-
-    # Content preview script
+    # Build content preview script
     content_script = ""
-    content_pipe_field = ""
     if include_content:
-        content_script = _build_content_script(max_content_length)
-        content_pipe_field = ' & "|||" & contentPreview'
+        content_script = f"""
+                            try
+                                set msgContent to content of aMessage
+                                set AppleScript's text item delimiters to {{return, linefeed}}
+                                set contentParts to text items of msgContent
+                                set AppleScript's text item delimiters to " "
+                                set cleanText to contentParts as string
+                                set AppleScript's text item delimiters to ""
 
-    # --- Account loop ---
+                                if {max_content_length} > 0 and length of cleanText > {max_content_length} then
+                                    set contentPreview to text 1 thru {max_content_length} of cleanText & "..."
+                                else
+                                    set contentPreview to cleanText
+                                end if
+
+                                set outputText to outputText & "   Content: " & contentPreview & return
+                            on error
+                                set outputText to outputText & "   Content: [Not available]" & return
+                            end try
+        """
+
+    # Escape user inputs for AppleScript
+    escaped_sender = escape_applescript(sender)
+    escaped_mailbox = escape_applescript(mailbox)
+    search_all_mailboxes = mailbox == "All"
+
+    # Build mailbox selection: INBOX-only (fast) vs all mailboxes
+    if search_all_mailboxes:
+        mailbox_loop_start = """
+                set accountMailboxes to every mailbox of anAccount
+                repeat with aMailbox in accountMailboxes
+                    set mailboxName to name of aMailbox
+                    -- Skip system and aggregate folders to avoid scanning huge mailboxes
+                    if mailboxName is not in {"Trash", "Junk", "Junk Email", "Deleted Items", "Deleted Messages", "Spam", "Drafts", "Sent", "Sent Items", "Sent Messages", "Sent Mail", "All Mail", "Bin"} then
+        """
+        mailbox_loop_end = f"""
+                        if resultCount >= {max_results} then exit repeat
+                    end if
+                end repeat
+        """
+    else:
+        mailbox_loop_start = f'''
+                -- Fast path: only search the target mailbox
+                try
+                    set aMailbox to mailbox "{escaped_mailbox}" of anAccount
+                on error
+                    if "{escaped_mailbox}" is "INBOX" then
+                        set aMailbox to mailbox "Inbox" of anAccount
+                    else
+                        error "Mailbox not found: {escaped_mailbox}"
+                    end if
+                end try
+                set mailboxName to name of aMailbox
+                if true then
+        '''
+        mailbox_loop_end = """
+                end if
+        """
+
+    # Build account iteration: direct access (fast) vs all accounts
     if account:
         escaped_account = escape_applescript(account)
-        acct_start = f"""
+        account_loop_start = f'''
         set anAccount to account "{escaped_account}"
         set accountName to name of anAccount
         repeat 1 times
-        """
-        acct_end = """
+        '''
+        account_loop_end = """
         end repeat
         """
     else:
-        acct_start = """
+        account_loop_start = f"""
         set allAccounts to every account
         repeat with anAccount in allAccounts
             set accountName to name of anAccount
         """
-        acct_end = f"""
+        account_loop_end = f"""
             if resultCount >= {max_results} then exit repeat
         end repeat
         """
 
-    # --- Mailbox loop ---
-    skip_cond = skip_folders_condition("mailboxName")
-    if mailbox == "All":
-        mbox_start = f"""
+    script = f'''
+    {LOWERCASE_HANDLER}
+
+    tell application "Mail"
+        set outputText to "EMAILS FROM SENDER: {escaped_sender}" & return
+        set outputText to outputText & "\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501" & return & return
+        set resultCount to 0
+
+        {date_filter_script}
+
+        {account_loop_start}
+
+            try
+                {mailbox_loop_start}
+
+                        set mailboxMessages to every message of aMailbox
+
+                        repeat with aMessage in mailboxMessages
+                            if resultCount >= {max_results} then exit repeat
+
+                            try
+                                set messageSender to sender of aMessage
+                                set messageDate to date received of aMessage
+
+                                -- Case-insensitive sender match
+                                set lowerSender to my lowercase(messageSender)
+                                set lowerSearch to my lowercase("{escaped_sender}")
+
+                                if lowerSender contains lowerSearch {date_check} then
+                                    set messageSubject to subject of aMessage
+                                    set messageRead to read status of aMessage
+
+                                    if messageRead then
+                                        set readIndicator to "\u2713"
+                                    else
+                                        set readIndicator to "\u2709"
+                                    end if
+
+                                    set outputText to outputText & readIndicator & " " & messageSubject & return
+                                    set outputText to outputText & "   From: " & messageSender & return
+                                    set outputText to outputText & "   Date: " & (messageDate as string) & return
+                                    set outputText to outputText & "   Account: " & accountName & return
+                                    set outputText to outputText & "   Mailbox: " & mailboxName & return
+
+                                    {content_script}
+
+                                    set outputText to outputText & return
+                                    set resultCount to resultCount + 1
+                                end if
+                            end try
+                        end repeat
+
+                {mailbox_loop_end}
+
+            on error errMsg
+                set outputText to outputText & "\u26a0 Error accessing mailboxes for " & accountName & ": " & errMsg & return
+            end try
+
+        {account_loop_end}
+
+        set outputText to outputText & "========================================" & return
+        set outputText to outputText & "FOUND: " & resultCount & " email(s) from sender" & return
+        if {days_back} > 0 then
+            set outputText to outputText & "Time range: Last {days_back} days" & return
+        end if
+        set outputText to outputText & "========================================" & return
+
+        return outputText
+    end tell
+    '''
+
+    result = run_applescript(script)
+    return result
+
+
+@mcp.tool()
+@inject_preferences
+def search_email_content(
+    account: str,
+    search_text: str,
+    mailbox: str = "INBOX",
+    search_subject: bool = True,
+    search_body: bool = True,
+    max_results: int = 10,
+    max_content_length: int = 600,
+) -> str:
+    """
+    Search email body content (and optionally subject).
+    This is slower than subject-only search but finds more relevant results.
+
+    Args:
+        account: Account name to search in
+        search_text: Text to search for in email content
+        mailbox: Mailbox to search (default: "INBOX")
+        search_subject: Also search in subject line (default: True)
+        search_body: Search in email body (default: True)
+        max_results: Maximum results to return (default: 10, keep low as this is slow)
+        max_content_length: Max content preview length (default: 600)
+
+    Returns:
+        Emails where the search text appears in body and/or subject
+    """
+    escaped_search = escape_applescript(search_text).lower()
+    escaped_account = escape_applescript(account)
+    escaped_mailbox = escape_applescript(mailbox)
+    search_conditions = []
+    if search_subject:
+        search_conditions.append(f'lowerSubject contains "{escaped_search}"')
+    if search_body:
+        search_conditions.append(f'lowerContent contains "{escaped_search}"')
+    search_condition = " or ".join(search_conditions) if search_conditions else "false"
+
+    script = f'''
+    {LOWERCASE_HANDLER}
+
+    tell application "Mail"
+        set outputText to "\U0001f50e CONTENT SEARCH: {escaped_search}" & return
+        set outputText to outputText & "\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501" & return
+        set outputText to outputText & "\u26a0 Note: Body search is slower - searching {max_results} results max" & return & return
+        set resultCount to 0
+        try
+            set targetAccount to account "{escaped_account}"
+            try
+                set targetMailbox to mailbox "{escaped_mailbox}" of targetAccount
+            on error
+                if "{escaped_mailbox}" is "INBOX" then
+                    set targetMailbox to mailbox "Inbox" of targetAccount
+                else
+                    error "Mailbox not found: {escaped_mailbox}"
+                end if
+            end try
+            set mailboxMessages to every message of targetMailbox
+            repeat with aMessage in mailboxMessages
+                if resultCount >= {max_results} then exit repeat
+                try
+                    set messageSubject to subject of aMessage
+                    set msgContent to ""
+                    try
+                        set msgContent to content of aMessage
+                    end try
+                    set lowerSubject to my lowercase(messageSubject)
+                    set lowerContent to my lowercase(msgContent)
+                    if {search_condition} then
+                        set messageSender to sender of aMessage
+                        set messageDate to date received of aMessage
+                        set messageRead to read status of aMessage
+                        if messageRead then
+                            set readIndicator to "\u2713"
+                        else
+                            set readIndicator to "\u2709"
+                        end if
+                        set outputText to outputText & readIndicator & " " & messageSubject & return
+                        set outputText to outputText & "   From: " & messageSender & return
+                        set outputText to outputText & "   Date: " & (messageDate as string) & return
+                        set outputText to outputText & "   Mailbox: {escaped_mailbox}" & return
+                        try
+                            set AppleScript's text item delimiters to {{return, linefeed}}
+                            set contentParts to text items of msgContent
+                            set AppleScript's text item delimiters to " "
+                            set cleanText to contentParts as string
+                            set AppleScript's text item delimiters to ""
+                            if length of cleanText > {max_content_length} then
+                                set contentPreview to text 1 thru {max_content_length} of cleanText & "..."
+                            else
+                                set contentPreview to cleanText
+                            end if
+                            set outputText to outputText & "   Content: " & contentPreview & return
+                        on error
+                            set outputText to outputText & "   Content: [Not available]" & return
+                        end try
+                        set outputText to outputText & return
+                        set resultCount to resultCount + 1
+                    end if
+                end try
+            end repeat
+            set outputText to outputText & "========================================" & return
+            set outputText to outputText & "FOUND: " & resultCount & " email(s) matching \\"{escaped_search}\\"" & return
+            set outputText to outputText & "========================================" & return
+        on error errMsg
+            return "Error: " & errMsg
+        end try
+        return outputText
+    end tell
+    '''
+    result = run_applescript(script)
+    return result
+
+
+@mcp.tool()
+@inject_preferences
+def get_newsletters(
+    account: Optional[str] = None,
+    days_back: int = 7,
+    max_results: int = 25,
+    include_content: bool = True,
+    max_content_length: int = 500,
+) -> str:
+    """
+    Find newsletter and digest emails by detecting common patterns.
+    Automatically identifies emails from newsletter services and digest senders.
+
+    Args:
+        account: Account to search. If None, searches all accounts.
+        days_back: Only search last N days (default: 7)
+        max_results: Maximum newsletters to return (default: 25)
+        include_content: Include content preview (default: True)
+        max_content_length: Max preview length (default: 500)
+
+    Returns:
+        List of detected newsletter emails sorted by date
+    """
+    # Escape user inputs for AppleScript
+    escaped_account = escape_applescript(account) if account else None
+
+    content_script = ""
+    if include_content:
+        content_script = f"""
+                                    try
+                                        set msgContent to content of aMessage
+                                        set AppleScript's text item delimiters to {{return, linefeed}}
+                                        set contentParts to text items of msgContent
+                                        set AppleScript's text item delimiters to " "
+                                        set cleanText to contentParts as string
+                                        set AppleScript's text item delimiters to ""
+                                        if length of cleanText > {max_content_length} then
+                                            set contentPreview to text 1 thru {max_content_length} of cleanText & "..."
+                                        else
+                                            set contentPreview to cleanText
+                                        end if
+                                        set outputText to outputText & "   Content: " & contentPreview & return
+                                    on error
+                                        set outputText to outputText & "   Content: [Not available]" & return
+                                    end try
+        """
+
+    account_filter_start = ""
+    account_filter_end = ""
+    if account:
+        account_filter_start = f'if accountName is "{escaped_account}" then'
+        account_filter_end = "end if"
+
+    date_filter = ""
+    date_check = ""
+    if days_back > 0:
+        date_filter = f"set cutoffDate to (current date) - ({days_back} * days)"
+        date_check = " and messageDate > cutoffDate"
+
+    script = f"""
+    {LOWERCASE_HANDLER}
+
+    tell application "Mail"
+        set outputText to "\U0001f4f0 NEWSLETTER DETECTION" & return
+        set outputText to outputText & "\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501" & return & return
+        set resultCount to 0
+        {date_filter}
+        set allAccounts to every account
+        repeat with anAccount in allAccounts
+            set accountName to name of anAccount
+            {account_filter_start}
+            try
                 set accountMailboxes to every mailbox of anAccount
                 repeat with aMailbox in accountMailboxes
                     try
                         set mailboxName to name of aMailbox
-                        if {skip_cond} then
+                        if mailboxName is "INBOX" or mailboxName is "Inbox" then
+                            set mailboxMessages to every message of aMailbox
+                            repeat with aMessage in mailboxMessages
+                                if resultCount >= {max_results} then exit repeat
+                                try
+                                    set messageSender to sender of aMessage
+                                    set messageDate to date received of aMessage
+                                    set lowerSender to my lowercase(messageSender)
+                                    set isNewsletter to false
+                                    if lowerSender contains "substack.com" or lowerSender contains "beehiiv.com" or lowerSender contains "mailchimp" or lowerSender contains "sendgrid" or lowerSender contains "convertkit" or lowerSender contains "buttondown" or lowerSender contains "ghost.io" or lowerSender contains "revue.co" or lowerSender contains "mailgun" then
+                                        set isNewsletter to true
+                                    end if
+                                    if lowerSender contains "newsletter" or lowerSender contains "digest" or lowerSender contains "weekly" or lowerSender contains "daily" or lowerSender contains "bulletin" or lowerSender contains "briefing" or lowerSender contains "news@" or lowerSender contains "updates@" then
+                                        set isNewsletter to true
+                                    end if
+                                    if isNewsletter{date_check} then
+                                        set messageSubject to subject of aMessage
+                                        set messageRead to read status of aMessage
+                                        if messageRead then
+                                            set readIndicator to "\u2713"
+                                        else
+                                            set readIndicator to "\u2709"
+                                        end if
+                                        set outputText to outputText & readIndicator & " " & messageSubject & return
+                                        set outputText to outputText & "   From: " & messageSender & return
+                                        set outputText to outputText & "   Date: " & (messageDate as string) & return
+                                        set outputText to outputText & "   Account: " & accountName & return
+                                        {content_script}
+                                        set outputText to outputText & return
+                                        set resultCount to resultCount + 1
+                                    end if
+                                end try
+                            end repeat
+                        end if
+                    end try
+                    if resultCount >= {max_results} then exit repeat
+                end repeat
+            end try
+            {account_filter_end}
+            if resultCount >= {max_results} then exit repeat
+        end repeat
+        set outputText to outputText & "========================================" & return
+        set outputText to outputText & "FOUND: " & resultCount & " newsletter(s)" & return
+        set outputText to outputText & "========================================" & return
+        return outputText
+    end tell
+    """
+    result = run_applescript(script)
+    return result
+
+
+@mcp.tool()
+@inject_preferences
+def get_recent_from_sender(
+    sender: str,
+    account: Optional[str] = None,
+    time_range: str = "week",
+    max_results: int = 15,
+    include_content: bool = True,
+    max_content_length: int = 400,
+    mailbox: str = "INBOX",
+) -> str:
+    """
+    Get recent emails from a specific sender with simple, human-friendly time filters.
+
+    Args:
+        sender: Sender name or email to search for (partial match)
+        account: Optional account. If None, searches all accounts.
+        time_range: Human-friendly time filter:
+            - "today" = last 24 hours
+            - "yesterday" = yesterday only
+            - "week" = last 7 days (default)
+            - "month" = last 30 days
+            - "all" = no time filter
+        max_results: Maximum emails to return (default: 15)
+        include_content: Include content preview (default: True)
+        max_content_length: Max preview length (default: 400)
+        mailbox: Mailbox to search (default: "INBOX", use "All" for all mailboxes)
+
+    Returns:
+        Recent emails from the specified sender within the time range
+    """
+    time_ranges = {"today": 1, "yesterday": 2, "week": 7, "month": 30, "all": 0}
+    days_back = time_ranges.get(time_range.lower(), 7)
+    is_yesterday = time_range.lower() == "yesterday"
+
+    content_script = ""
+    if include_content:
+        content_script = f"""
+                                    try
+                                        set msgContent to content of aMessage
+                                        set AppleScript's text item delimiters to {{return, linefeed}}
+                                        set contentParts to text items of msgContent
+                                        set AppleScript's text item delimiters to " "
+                                        set cleanText to contentParts as string
+                                        set AppleScript's text item delimiters to ""
+                                        if length of cleanText > {max_content_length} then
+                                            set contentPreview to text 1 thru {max_content_length} of cleanText & "..."
+                                        else
+                                            set contentPreview to cleanText
+                                        end if
+                                        set outputText to outputText & "   Content: " & contentPreview & return
+                                    on error
+                                        set outputText to outputText & "   Content: [Not available]" & return
+                                    end try
         """
-        mbox_end = f"""
+
+    # Escape user inputs for AppleScript
+    escaped_sender = escape_applescript(sender)
+    escaped_mailbox = escape_applescript(mailbox)
+    search_all_mailboxes = mailbox == "All"
+
+    date_filter = ""
+    date_check = ""
+    if days_back > 0:
+        date_filter = f"set cutoffDate to (current date) - ({days_back} * days)"
+        if is_yesterday:
+            date_filter += """
+            set todayStart to (current date) - (time of (current date))
+            set yesterdayStart to todayStart - (1 * days)
+            """
+            date_check = (
+                " and messageDate >= yesterdayStart and messageDate < todayStart"
+            )
+        else:
+            date_check = " and messageDate > cutoffDate"
+
+    # Build mailbox selection: INBOX-only (fast) vs all mailboxes
+    if search_all_mailboxes:
+        mailbox_loop_start = """
+                set accountMailboxes to every mailbox of anAccount
+                repeat with aMailbox in accountMailboxes
+                    try
+                        set mailboxName to name of aMailbox
+                        if mailboxName is not in {"Trash", "Junk", "Junk Email", "Deleted Items", "Deleted Messages", "Spam", "Drafts", "Sent", "Sent Items", "Sent Messages", "Sent Mail", "All Mail", "Bin"} then
+        """
+        mailbox_loop_end = f"""
                         end if
                     end try
                     if resultCount >= {max_results} then exit repeat
                 end repeat
         """
     else:
-        mbox_ref = build_mailbox_ref(mailbox, account_var="anAccount", var_name="aMailbox")
-        mbox_start = f"""
-                {mbox_ref}
+        mailbox_loop_start = f'''
+                -- Fast path: only search the target mailbox
+                try
+                    set aMailbox to mailbox "{escaped_mailbox}" of anAccount
+                on error
+                    if "{escaped_mailbox}" is "INBOX" then
+                        set aMailbox to mailbox "Inbox" of anAccount
+                    else
+                        error "Mailbox not found: {escaped_mailbox}"
+                    end if
+                end try
                 set mailboxName to name of aMailbox
                 if true then
-        """
-        mbox_end = """
+        '''
+        mailbox_loop_end = """
                 end if
         """
 
-    # --- Output record (per matching message) ---
-    if output_format == "json":
-        record_script = f"""
-                                    set end of resultLines to messageSubject & "|||" & messageSender & "|||" & (messageDate as string) & "|||" & messageRead & "|||" & accountName & "|||" & mailboxName{content_pipe_field}
-        """
-        output_setup = "set resultLines to {}"
-        output_return = """
-        set AppleScript's text item delimiters to linefeed
-        return resultLines as string
-        """
-    else:
-        content_text_line = ""
-        if include_content:
-            content_text_line = """
-                                    set outputText to outputText & "   Content: " & contentPreview & return
-            """
-        record_script = f"""
-                                    if messageRead then
-                                        set ri to "Read"
-                                    else
-                                        set ri to "UNREAD"
-                                    end if
-                                    set outputText to outputText & "[" & ri & "] " & messageSubject & return
-                                    set outputText to outputText & "   From: " & messageSender & return
-                                    set outputText to outputText & "   Date: " & (messageDate as string) & return
-                                    set outputText to outputText & "   Account: " & accountName & return
-                                    set outputText to outputText & "   Mailbox: " & mailboxName & return
-                                    {content_text_line}
-                                    set outputText to outputText & return
-        """
-        output_setup = 'set outputText to "SEARCH RESULTS" & return & return'
-        output_return = f"""
-        set outputText to outputText & "========================================" & return
-        set outputText to outputText & "FOUND: " & resultCount & " email(s)" & return
-        set outputText to outputText & "========================================" & return
-        return outputText
-        """
-
-    # --- Post-filter wrapper ---
-    if post_filter_block:
-        post_filter_start = f"""
-                                set skipMsg to false
-                                {post_filter_block}
-                                if not skipMsg then
-        """
-        post_filter_end = """
-                                end if
+    # Build account iteration: direct access (fast) vs all accounts
+    if account:
+        escaped_account = escape_applescript(account)
+        account_loop_start = f'''
+        set anAccount to account "{escaped_account}"
+        set accountName to name of anAccount
+        repeat 1 times
+        '''
+        account_loop_end = """
+        end repeat
         """
     else:
-        post_filter_start = ""
-        post_filter_end = ""
+        account_loop_start = f"""
+        set allAccounts to every account
+        repeat with anAccount in allAccounts
+            set accountName to name of anAccount
+        """
+        account_loop_end = f"""
+            if resultCount >= {max_results} then exit repeat
+        end repeat
+        """
 
-    # --- Assemble the full script ---
-    lowercase_handler = LOWERCASE_HANDLER if needs_lowercase else ""
-
-    script = f"""
-    {lowercase_handler}
+    script = f'''
+    {LOWERCASE_HANDLER}
 
     tell application "Mail"
-        {output_setup}
+        set outputText to "\U0001f4e7 EMAILS FROM: {escaped_sender}" & return
+        set outputText to outputText & "\u23f0 Time range: {time_range}" & return
+        set outputText to outputText & "\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501" & return & return
         set resultCount to 0
-        {date_setup}
+        {date_filter}
 
-        {acct_start}
+        {account_loop_start}
 
             try
-                {mbox_start}
+                {mailbox_loop_start}
 
-                        {fetch_script}
+                            set mailboxMessages to every message of aMailbox
+                            repeat with aMessage in mailboxMessages
+                                if resultCount >= {max_results} then exit repeat
+                                try
+                                    set messageSender to sender of aMessage
+                                    set messageDate to date received of aMessage
+                                    set lowerSender to my lowercase(messageSender)
+                                    set lowerSearch to my lowercase("{escaped_sender}")
+                                    if lowerSender contains lowerSearch{date_check} then
+                                        set messageSubject to subject of aMessage
+                                        set messageRead to read status of aMessage
+                                        if messageRead then
+                                            set readIndicator to "\u2713"
+                                        else
+                                            set readIndicator to "\u2709"
+                                        end if
+                                        set outputText to outputText & readIndicator & " " & messageSubject & return
+                                        set outputText to outputText & "   From: " & messageSender & return
+                                        set outputText to outputText & "   Date: " & (messageDate as string) & return
+                                        set outputText to outputText & "   Account: " & accountName & return
+                                        {content_script}
+                                        set outputText to outputText & return
+                                        set resultCount to resultCount + 1
+                                    end if
+                                end try
+                            end repeat
 
-                        repeat with aMessage in matchedMessages
-                            if resultCount >= {max_results} then exit repeat
-                            try
-                                set messageSubject to subject of aMessage
-                                set messageSender to sender of aMessage
-                                set messageDate to date received of aMessage
-                                set messageRead to read status of aMessage
+                {mailbox_loop_end}
 
-                                {post_filter_start}
-                                    {content_script}
-                                    {record_script}
-                                    set resultCount to resultCount + 1
-                                {post_filter_end}
-                            end try
-                        end repeat
-
-                {mbox_end}
-
-            on error errMsg
-                -- Skip account/mailbox on error
             end try
 
-        {acct_end}
+        {account_loop_end}
 
-        {output_return}
+        set outputText to outputText & "========================================" & return
+        set outputText to outputText & "FOUND: " & resultCount & " email(s) from sender" & return
+        set outputText to outputText & "========================================" & return
+        return outputText
     end tell
+    '''
+    result = run_applescript(script)
+    return result
+
+
+@mcp.tool()
+@inject_preferences
+def get_email_thread(
+    account: str, subject_keyword: str, mailbox: str = "INBOX", max_messages: int = 50
+) -> str:
+    """
+    Get an email conversation thread - all messages with the same or similar subject.
+
+    Args:
+        account: Account name (e.g., "Gmail", "Work")
+        subject_keyword: Keyword to identify the thread (e.g., "Re: Project Update")
+        mailbox: Mailbox to search in (default: "INBOX", use "All" for all mailboxes)
+        max_messages: Maximum number of thread messages to return (default: 50)
+
+    Returns:
+        Formatted thread view with all related messages sorted by date
     """
 
-    raw = run_applescript(script)
+    # Escape user inputs for AppleScript
+    escaped_account = escape_applescript(account)
+    escaped_mailbox = escape_applescript(mailbox)
 
-    if output_format == "json":
-        emails = _parse_pipe_output(raw)
-        return json.dumps(emails, indent=2)
+    # For thread detection, we'll strip common prefixes
+    thread_keywords = ["Re:", "Fwd:", "FW:", "RE:", "Fw:"]
+    cleaned_keyword = subject_keyword
+    for prefix in thread_keywords:
+        cleaned_keyword = cleaned_keyword.replace(prefix, "").strip()
+    escaped_keyword = escape_applescript(cleaned_keyword)
 
-    return raw
+    mailbox_script = f'''
+        try
+            set searchMailbox to mailbox "{escaped_mailbox}" of targetAccount
+        on error
+            if "{escaped_mailbox}" is "INBOX" then
+                set searchMailbox to mailbox "Inbox" of targetAccount
+            else if "{escaped_mailbox}" is "All" then
+                set searchMailboxes to every mailbox of targetAccount
+                set useAllMailboxes to true
+            else
+                error "Mailbox not found: {escaped_mailbox}"
+            end if
+        end try
+
+        if "{escaped_mailbox}" is not "All" then
+            set searchMailboxes to {{searchMailbox}}
+            set useAllMailboxes to false
+        end if
+    '''
+
+    script = f'''
+    tell application "Mail"
+        set outputText to "EMAIL THREAD VIEW" & return & return
+        set outputText to outputText & "Thread topic: {escaped_keyword}" & return
+        set outputText to outputText & "Account: {escaped_account}" & return & return
+        set threadMessages to {{}}
+
+        try
+            set targetAccount to account "{escaped_account}"
+            {mailbox_script}
+
+            -- Collect all matching messages from all mailboxes
+            repeat with currentMailbox in searchMailboxes
+                set mailboxMessages to every message of currentMailbox
+
+                repeat with aMessage in mailboxMessages
+                    if (count of threadMessages) >= {max_messages} then exit repeat
+
+                    try
+                        set messageSubject to subject of aMessage
+
+                        -- Remove common prefixes for matching
+                        set cleanSubject to messageSubject
+                        if cleanSubject starts with "Re: " then
+                            set cleanSubject to text 5 thru -1 of cleanSubject
+                        end if
+                        if cleanSubject starts with "Fwd: " or cleanSubject starts with "FW: " then
+                            set cleanSubject to text 6 thru -1 of cleanSubject
+                        end if
+
+                        -- Check if this message is part of the thread
+                        if cleanSubject contains "{escaped_keyword}" or messageSubject contains "{escaped_keyword}" then
+                            set end of threadMessages to aMessage
+                        end if
+                    end try
+                end repeat
+            end repeat
+
+            -- Display thread messages
+            set messageCount to count of threadMessages
+            set outputText to outputText & "\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501" & return
+            set outputText to outputText & "FOUND " & messageCount & " MESSAGE(S) IN THREAD" & return
+            set outputText to outputText & "\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501" & return & return
+
+            repeat with aMessage in threadMessages
+                try
+                    set messageSubject to subject of aMessage
+                    set messageSender to sender of aMessage
+                    set messageDate to date received of aMessage
+                    set messageRead to read status of aMessage
+
+                    if messageRead then
+                        set readIndicator to "\u2713"
+                    else
+                        set readIndicator to "\u2709"
+                    end if
+
+                    set outputText to outputText & readIndicator & " " & messageSubject & return
+                    set outputText to outputText & "   From: " & messageSender & return
+                    set outputText to outputText & "   Date: " & (messageDate as string) & return
+
+                    -- Get content preview
+                    try
+                        set msgContent to content of aMessage
+                        set AppleScript's text item delimiters to {{return, linefeed}}
+                        set contentParts to text items of msgContent
+                        set AppleScript's text item delimiters to " "
+                        set cleanText to contentParts as string
+                        set AppleScript's text item delimiters to ""
+
+                        if length of cleanText > 150 then
+                            set contentPreview to text 1 thru 150 of cleanText & "..."
+                        else
+                            set contentPreview to cleanText
+                        end if
+
+                        set outputText to outputText & "   Preview: " & contentPreview & return
+                    end try
+
+                    set outputText to outputText & return
+                end try
+            end repeat
+
+        on error errMsg
+            return "Error: " & errMsg
+        end try
+
+        return outputText
+    end tell
+    '''
+
+    result = run_applescript(script)
+    return result
+
+
+@mcp.tool()
+@inject_preferences
+def search_all_accounts(
+    subject_keyword: Optional[str] = None,
+    sender: Optional[str] = None,
+    days_back: int = 7,
+    max_results: int = 30,
+    include_content: bool = True,
+    max_content_length: int = 400,
+) -> str:
+    """
+    Search across ALL email accounts at once.
+
+    Returns consolidated results sorted by date (newest first).
+    Only searches INBOX mailboxes (skips Trash, Junk, Drafts, Sent).
+
+    Args:
+        subject_keyword: Optional keyword to search in subject
+        sender: Optional sender email or name to filter by
+        days_back: Number of days to look back (default: 7, 0 = all time)
+        max_results: Maximum total results across all accounts (default: 30)
+        include_content: Whether to include email content preview (default: True)
+        max_content_length: Maximum content length in characters (default: 400)
+
+    Returns:
+        Formatted list of matching emails with account name for each
+    """
+    # Build date filter
+    date_filter = ""
+    if days_back > 0:
+        date_filter = f"""
+            set cutoffDate to (current date) - ({days_back} * days)
+            if messageDate < cutoffDate then
+                set skipMessage to true
+            end if
+        """
+
+    # Build subject filter
+    subject_filter = ""
+    if subject_keyword:
+        escaped_keyword = escape_applescript(subject_keyword)
+        subject_filter = f'''
+            set lowerSubject to my lowercase(messageSubject)
+            set lowerKeyword to my lowercase("{escaped_keyword}")
+            if lowerSubject does not contain lowerKeyword then
+                set skipMessage to true
+            end if
+        '''
+
+    # Build sender filter
+    sender_filter = ""
+    if sender:
+        escaped_sender = escape_applescript(sender)
+        sender_filter = f'''
+            set lowerSender to my lowercase(messageSender)
+            set lowerSenderFilter to my lowercase("{escaped_sender}")
+            if lowerSender does not contain lowerSenderFilter then
+                set skipMessage to true
+            end if
+        '''
+
+    # Build content retrieval
+    content_retrieval = ""
+    if include_content:
+        content_retrieval = f"""
+            try
+                set messageContent to content of msg
+                if length of messageContent > {max_content_length} then
+                    set messageContent to text 1 thru {max_content_length} of messageContent & "..."
+                end if
+                -- Clean up content for display
+                set messageContent to my replaceText(messageContent, return, " ")
+                set messageContent to my replaceText(messageContent, linefeed, " ")
+            on error
+                set messageContent to "(Content unavailable)"
+            end try
+            set emailRecord to emailRecord & "Content: " & messageContent & linefeed
+        """
+
+    script = f"""
+        {LOWERCASE_HANDLER}
+
+        on replaceText(theText, searchStr, replaceStr)
+            set AppleScript\'s text item delimiters to searchStr
+            set theItems to text items of theText
+            set AppleScript\'s text item delimiters to replaceStr
+            set theText to theItems as text
+            set AppleScript\'s text item delimiters to ""
+            return theText
+        end replaceText
+
+        tell application "Mail"
+            set allResults to {{}}
+            set allAccounts to every account
+
+            repeat with acct in allAccounts
+                set acctName to name of acct
+
+                -- Find INBOX mailbox
+                set inboxMailbox to missing value
+                try
+                    set inboxMailbox to mailbox "INBOX" of acct
+                on error
+                    -- Try to find inbox by checking mailboxes
+                    repeat with mb in mailboxes of acct
+                        set mbName to name of mb
+                        if mbName is "INBOX" or mbName is "Inbox" then
+                            set inboxMailbox to mb
+                            exit repeat
+                        end if
+                    end repeat
+                end try
+
+                if inboxMailbox is not missing value then
+                    try
+                        set msgs to messages of inboxMailbox
+
+                        repeat with msg in msgs
+                            set skipMessage to false
+
+                            try
+                                set messageSubject to subject of msg
+                                set messageSender to sender of msg
+                                set messageDate to date received of msg
+                                set messageRead to read status of msg
+                            on error
+                                set skipMessage to true
+                            end try
+
+                            if not skipMessage then
+                                {date_filter}
+                            end if
+
+                            if not skipMessage then
+                                {subject_filter}
+                            end if
+
+                            if not skipMessage then
+                                {sender_filter}
+                            end if
+
+                            if not skipMessage then
+                                -- Build email record
+                                set emailRecord to ""
+                                set emailRecord to emailRecord & "Account: " & acctName & linefeed
+                                set emailRecord to emailRecord & "Subject: " & messageSubject & linefeed
+                                set emailRecord to emailRecord & "From: " & messageSender & linefeed
+                                set emailRecord to emailRecord & "Date: " & (messageDate as string) & linefeed
+                                if messageRead then
+                                    set emailRecord to emailRecord & "Status: Read" & linefeed
+                                else
+                                    set emailRecord to emailRecord & "Status: UNREAD" & linefeed
+                                end if
+                                {content_retrieval}
+
+                                -- Store with date for sorting
+                                set end of allResults to {{emailDate:messageDate, emailText:emailRecord}}
+                            end if
+
+                            -- Check if we have enough results
+                            if (count of allResults) >= {max_results} then
+                                exit repeat
+                            end if
+                        end repeat
+                    on error errMsg
+                        -- Skip this account if there\'s an error
+                    end try
+                end if
+
+                -- Check if we have enough results
+                if (count of allResults) >= {max_results} then
+                    exit repeat
+                end if
+            end repeat
+
+            -- Sort results by date (newest first)
+            set sortedResults to my sortByDate(allResults)
+
+            -- Build output
+            set outputText to ""
+            set emailCount to count of sortedResults
+
+            if emailCount is 0 then
+                return "No emails found matching your criteria across all accounts."
+            end if
+
+            set outputText to "=== Cross-Account Search Results ===" & linefeed
+            set outputText to outputText & "Found " & emailCount & " email(s)" & linefeed
+            set outputText to outputText & "---" & linefeed & linefeed
+
+            repeat with emailItem in sortedResults
+                set outputText to outputText & emailText of emailItem & linefeed & "---" & linefeed
+            end repeat
+
+            return outputText
+        end tell
+
+        on sortByDate(theList)
+            -- Simple bubble sort by date (descending - newest first)
+            set listLength to count of theList
+            repeat with i from 1 to listLength - 1
+                repeat with j from 1 to listLength - i
+                    if emailDate of item j of theList < emailDate of item (j + 1) of theList then
+                        set temp to item j of theList
+                        set item j of theList to item (j + 1) of theList
+                        set item (j + 1) of theList to temp
+                    end if
+                end repeat
+            end repeat
+            return theList
+        end sortByDate
+    """
+
+    result = run_applescript(script)
+    return result

--- a/skill-email-management/SKILL.md
+++ b/skill-email-management/SKILL.md
@@ -21,7 +21,7 @@ The Apple Mail MCP provides comprehensive email management capabilities:
 
 - **Overview & Discovery**: `get_inbox_overview`, `list_accounts`, `list_mailboxes`
 - **Reading & Searching**: `list_inbox_emails`, `get_recent_emails`, `get_email_with_content`, `search_emails`, `get_email_thread`, `search_by_sender`, `search_all_accounts`, `search_email_content`, `get_newsletters`
-- **Composing & Responding**: `compose_email`, `reply_to_email`, `forward_email`
+- **Composing & Responding**: `compose_email`, `reply_to_email`, `forward_email`, `create_rich_email_draft`
 - **Organization**: `move_email`, `update_email_status` (read/unread, flag/unflag)
 - **Drafts**: `manage_drafts` (list, create, send, delete)
 - **Attachments**: `list_email_attachments`, `save_email_attachment`
@@ -39,8 +39,9 @@ The Apple Mail MCP provides comprehensive email management capabilities:
 1. **Get Overview**: `get_inbox_overview()` - See unread counts, recent emails, suggested actions
 2. **Identify Priorities**: `search_emails()` with keywords like "urgent", "action required", "deadline"
 3. **Quick Responses**:
-   - For immediate replies: `reply_to_email()`
-   - For considered responses: `manage_drafts(action="create")`
+    - For immediate replies: `reply_to_email()`
+    - For considered responses: `manage_drafts(action="create")`
+    - For rich newsletters, status updates, or HTML-heavy drafts: `create_rich_email_draft()`
 4. **Organize by Category**:
    - Move project emails: `move_email(to_mailbox="Projects/[ProjectName]")`
    - Archive processed: `move_email(to_mailbox="Archive")`
@@ -179,6 +180,25 @@ The Apple Mail MCP provides comprehensive email management capabilities:
 - Create drafts for emails needing careful wording
 - Review drafts weekly to avoid accumulation
 - Use descriptive subjects for easy draft identification
+
+### 7a. Rich Text / HTML Draft Workflow
+
+**Goal**: Create a rendered Mail compose window for rich email content without Mail showing literal HTML.
+
+**When to use it**:
+- Weekly updates and leadership emails
+- Newsletters or formatted announcements
+- Any case where the assistant only has partial details but should prepare a polished draft quickly
+
+**Preferred workflow**:
+1. Build the HTML content first
+2. Use `create_rich_email_draft()` instead of `manage_drafts(action="create")`
+3. Pass as many details as you have now; missing `to`, `subject`, or `body` can be filled in later
+4. Let the tool generate and open an unsent `.eml` draft in Mail
+5. Optionally save that compose window into Drafts
+
+**Important note**:
+- Do not inject raw HTML into the normal AppleScript `content` field for rich messages; Mail commonly stores that as visible markup rather than rendered formatting.
 
 ### 8. Thread Management
 

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -1,0 +1,91 @@
+"""Tests for compose and rich draft helpers."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from apple_mail_mcp.tools import compose as compose_tools
+
+
+class ComposeToolTests(unittest.TestCase):
+    def test_create_rich_email_draft_writes_multipart_eml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "weekly-update.eml"
+
+            with (
+                patch(
+                    "apple_mail_mcp.tools.compose.run_applescript",
+                    return_value="sender@example.com",
+                ),
+                patch("apple_mail_mcp.tools.compose.subprocess.run") as mock_run,
+            ):
+                result = compose_tools.create_rich_email_draft(
+                    account="Work",
+                    subject="Weekly Update",
+                    to="team@example.com",
+                    text_body="Plain fallback",
+                    html_body="<html><body><h1>Weekly Update</h1></body></html>",
+                    output_path=str(output_path),
+                    open_in_mail=True,
+                )
+
+            payload = output_path.read_text()
+            self.assertIn("multipart/alternative", payload)
+            self.assertIn("<h1>Weekly Update</h1>", payload)
+            self.assertIn("Subject: Weekly Update", payload)
+            self.assertIn("Opened in Mail: yes", result)
+            mock_run.assert_called_once_with(
+                ["open", "-a", "Mail", str(output_path)], check=True
+            )
+
+    def test_create_rich_email_draft_allows_partial_details(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "partial.eml"
+
+            with (
+                patch(
+                    "apple_mail_mcp.tools.compose.run_applescript",
+                    return_value="sender@example.com",
+                ),
+                patch("apple_mail_mcp.tools.compose.subprocess.run"),
+            ):
+                result = compose_tools.create_rich_email_draft(
+                    account="Work",
+                    output_path=str(output_path),
+                    open_in_mail=False,
+                )
+
+            payload = output_path.read_text()
+            self.assertIn("Draft outline", payload)
+            self.assertIn("Missing details: subject, to, body", result)
+            self.assertIn("Opened in Mail: no", result)
+
+    def test_create_rich_email_draft_can_save_to_drafts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "saved.eml"
+            run_results = ["sender@example.com", "saved"]
+
+            def fake_run_applescript(script, timeout=120):
+                return run_results.pop(0)
+
+            with (
+                patch(
+                    "apple_mail_mcp.tools.compose.run_applescript",
+                    side_effect=fake_run_applescript,
+                ),
+                patch("apple_mail_mcp.tools.compose.subprocess.run"),
+            ):
+                result = compose_tools.create_rich_email_draft(
+                    account="Work",
+                    subject="Saved Draft",
+                    output_path=str(output_path),
+                    open_in_mail=True,
+                    save_as_draft=True,
+                )
+
+            self.assertIn("Saved in Drafts: yes", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -1,0 +1,217 @@
+"""Tests for structured email search and bulk update helpers."""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from apple_mail_mcp.tools import manage as manage_tools
+from apple_mail_mcp.tools import search as search_tools
+
+
+def _record_line(
+    message_id,
+    subject,
+    internet_message_id="<abc@example.com>",
+    sender="sender@example.com",
+    mailbox="INBOX",
+    account="Work",
+    is_read=False,
+    received_date="2026-03-07T10:00:00",
+    content_preview="",
+):
+    return "|||".join(
+        [
+            str(message_id),
+            internet_message_id,
+            subject,
+            sender,
+            mailbox,
+            account,
+            "true" if is_read else "false",
+            received_date,
+            content_preview,
+        ]
+    )
+
+
+class SearchToolTests(unittest.TestCase):
+    def test_search_emails_pagination_consistency(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return "\n".join(
+                [
+                    _record_line(
+                        100,
+                        "Ticket 100",
+                        received_date="2026-03-07T12:00:00",
+                    ),
+                    _record_line(
+                        101,
+                        "Ticket 101",
+                        received_date="2026-03-07T11:00:00",
+                    ),
+                    _record_line(
+                        102,
+                        "Ticket 102",
+                        received_date="2026-03-07T10:00:00",
+                    ),
+                ]
+            )
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            response = json.loads(
+                search_tools.search_emails(
+                    account="Work",
+                    output_format="json",
+                    offset=1,
+                    limit=2,
+                    max_results=None,
+                )
+            )
+
+        self.assertEqual(response["offset"], 1)
+        self.assertEqual(response["returned"], 2)
+        self.assertTrue(response["has_more"])
+        self.assertEqual(response["next_offset"], 3)
+        self.assertEqual(
+            response["items"][0]["mail_link"],
+            "message:%3Cabc%40example.com%3E",
+        )
+        self.assertIn("set offsetRemaining to 1", captured["script"])
+        self.assertIn("set collectLimit to 3", captured["script"])
+
+    def test_search_subjects_unread_only_filter(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return _record_line(201, "Unread Ticket", is_read=False)
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            response = json.loads(
+                search_tools.search_subjects(
+                    account="Work",
+                    subject_keyword="Ticket",
+                    read_status="unread",
+                    output_format="json",
+                    limit=1,
+                )
+            )
+
+        self.assertEqual(len(response["items"]), 1)
+        self.assertFalse(response["items"][0]["is_read"])
+        self.assertIn("read status is false", captured["script"])
+
+    def test_search_emails_builds_real_date_filters(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return _record_line(
+                301,
+                "Dated Ticket",
+                received_date="2026-03-05T09:00:00",
+            )
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            response = json.loads(
+                search_tools.search_emails(
+                    account="Work",
+                    subject_keyword="Ticket",
+                    date_from="2026-03-01",
+                    date_to="2026-03-07",
+                    output_format="json",
+                    limit=1,
+                    max_results=None,
+                )
+            )
+
+        self.assertEqual(response["items"][0]["message_id"], "301")
+        self.assertIn("set year of fromDate to 2026", captured["script"])
+        self.assertIn("set month of fromDate to March", captured["script"])
+        self.assertIn("date received >= fromDate", captured["script"])
+        self.assertIn("date received <= toDate", captured["script"])
+
+    def test_large_mailbox_search_uses_prefiltered_selection(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            response = json.loads(
+                search_tools.search_emails(
+                    account="Work",
+                    subject_keywords=["INC-1", "INC-2"],
+                    include_content=False,
+                    output_format="json",
+                    limit=50,
+                    max_results=None,
+                )
+            )
+
+        self.assertEqual(response["items"], [])
+        self.assertIn(
+            "set matchingMessages to every message of currentMailbox whose",
+            captured["script"],
+        )
+        self.assertNotIn(
+            "set mailboxMessages to every message of currentMailbox", captured["script"]
+        )
+
+    def test_search_emails_returns_mail_link_from_internet_message_id(self):
+        def fake_run(script, timeout=120):
+            return _record_line(
+                401,
+                "Linked Ticket",
+                internet_message_id="<QwcH6OP9REaEX0pi8aR6-g@geopod-ismtpd-60>",
+            )
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            response = json.loads(
+                search_tools.search_emails(
+                    account="Work",
+                    subject_keyword="Linked",
+                    output_format="json",
+                    limit=1,
+                    max_results=None,
+                )
+            )
+
+        self.assertEqual(
+            response["items"][0]["internet_message_id"],
+            "<QwcH6OP9REaEX0pi8aR6-g@geopod-ismtpd-60>",
+        )
+        self.assertEqual(
+            response["items"][0]["mail_link"],
+            "message:%3CQwcH6OP9REaEX0pi8aR6-g%40geopod-ismtpd-60%3E",
+        )
+
+
+class ManageToolTests(unittest.TestCase):
+    def test_update_email_status_by_ids_uses_exact_id_condition(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return "updated"
+
+        with patch("apple_mail_mcp.tools.manage.run_applescript", side_effect=fake_run):
+            result = manage_tools.update_email_status_by_ids(
+                account="Work",
+                mailbox="INBOX",
+                message_ids=["101", "202"],
+                action="mark_read",
+            )
+
+        self.assertEqual(result, "updated")
+        self.assertIn("id is 101", captured["script"])
+        self.assertIn("id is 202", captured["script"])
+        self.assertIn("set read status of targetMessages to true", captured["script"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `create_rich_email_draft` plus supporting docs so rich HTML drafts can be generated as `.eml` files and opened or saved in Mail more reliably than raw AppleScript HTML
- merge in structured inbox/search/manage improvements, including JSON-friendly search results, mailbox unread counts, multi-keyword matching, and message-id based status updates
- cover the new compose and search behavior with unittest cases for rich draft generation, pagination, date filters, mail links, and exact-id status updates

## Validation
- `python3 -m unittest discover -s tests`
- `python3 -c \"import apple_mail_mcp\"`