### PR TITLE
Fix: preserve Unicode in MCP output

### DIFF
--- a/apple_mail_mcp/core.py
+++ b/apple_mail_mcp/core.py
@@ -41,15 +41,13 @@ def escape_applescript(value: str) -> str:
 def _sanitize_for_json(text: str) -> str:
     """Sanitize text for safe JSON serialization over MCP stdio transport.
 
-    Forces ASCII-safe output to avoid encoding issues in the
-    Desktop <-> CLI <-> MCP communication chain.
+    Preserves Unicode (including Cyrillic, CJK, Arabic, etc.) while
+    stripping control characters.
     """
     # Normalize line endings first (AppleScript uses \r)
     text = text.replace("\r\n", "\n").replace("\r", "\n")
-    # Force ASCII: replaces non-ASCII chars with their Unicode escape or drops them
-    text = text.encode("ascii", "replace").decode("ascii")
-    # Strip remaining control characters (keep \n and \t)
-    return "".join(ch for ch in text if ch in ("\n", "\t") or (" " <= ch <= "~"))
+    # Strip control characters but keep \n, \t, and all printable Unicode
+    return "".join(ch for ch in text if ch in ("\n", "\t") or (ord(ch) >= 32))
 
 
 def run_applescript(script: str, timeout: int = 120) -> str:


### PR DESCRIPTION
## Summary
- `_sanitize_for_json()` in `core.py` encodes all text to ASCII via `text.encode("ascii", "replace")`, replacing every non-ASCII character with `?`
- This breaks output for all non-Latin scripts: Cyrillic, CJK, Arabic, Hebrew, etc.
- Replaced with a filter that strips control characters while preserving all printable Unicode

## Before / After
- Before: `Привет мир` → `?????? ???`
- After: `Привет мир` → `Привет мир`

## Test plan
- [ ] Verify emails with non-ASCII content (Cyrillic, CJK) display correctly
- [ ] Verify ASCII-only emails still work unchanged
- [ ] Verify JSON serialization over stdio remains valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)