### PR TITLE
fix: produce working Apple Mail deep links from search results

### DIFF
--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -79,7 +79,11 @@ def _parse_search_records(output: str) -> List[Dict[str, Any]]:
             "received_date": parts[7].strip(),
         }
         if internet_message_id:
-            record["mail_link"] = "message:" + quote(internet_message_id, safe="")
+            # Apple Mail requires: message:// scheme, angle brackets (percent-encoded),
+            # and raw @ in the Message-ID. Normalize ID in case angle brackets are
+            # present or missing (AppleScript returns both forms).
+            msg_id = internet_message_id.strip("<>")
+            record["mail_link"] = f"message://%3C{quote(msg_id, safe='@')}%3E"
         if len(parts) > 8 and parts[8].strip():
             record["content_preview"] = parts[8].strip()
         records.append(record)

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -77,7 +77,7 @@ class SearchToolTests(unittest.TestCase):
         self.assertEqual(response["next_offset"], 3)
         self.assertEqual(
             response["items"][0]["mail_link"],
-            "message:%3Cabc%40example.com%3E",
+            "message://%3Cabc@example.com%3E",
         )
         self.assertIn("set offsetRemaining to 1", captured["script"])
         self.assertIn("set collectLimit to 3", captured["script"])
@@ -188,7 +188,7 @@ class SearchToolTests(unittest.TestCase):
         )
         self.assertEqual(
             response["items"][0]["mail_link"],
-            "message:%3CQwcH6OP9REaEX0pi8aR6-g%40geopod-ismtpd-60%3E",
+            "message://%3CQwcH6OP9REaEX0pi8aR6-g@geopod-ismtpd-60%3E",
         )
 
     def test_search_emails_account_none_iterates_all_accounts(self):

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -191,6 +191,37 @@ class SearchToolTests(unittest.TestCase):
             "message://%3CQwcH6OP9REaEX0pi8aR6-g@geopod-ismtpd-60%3E",
         )
 
+    def test_search_emails_mail_link_normalizes_missing_angle_brackets(self):
+        """AppleScript sometimes returns the Message-ID without angle brackets;
+        the mail_link should still include them (percent-encoded)."""
+
+        def fake_run(script, timeout=120):
+            return _record_line(
+                402,
+                "Unbracketed Ticket",
+                internet_message_id="abc@example.com",
+            )
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            response = json.loads(
+                search_tools.search_emails(
+                    account="Work",
+                    subject_keyword="Unbracketed",
+                    output_format="json",
+                    limit=1,
+                    max_results=None,
+                )
+            )
+
+        self.assertEqual(
+            response["items"][0]["internet_message_id"],
+            "abc@example.com",
+        )
+        self.assertEqual(
+            response["items"][0]["mail_link"],
+            "message://%3Cabc@example.com%3E",
+        )
+
     def test_search_emails_account_none_iterates_all_accounts(self):
         """When account is None, the script should iterate all accounts."""
         captured = {}


### PR DESCRIPTION
## Problem

The `mail_link` field in `search_emails` results produces URLs that Apple Mail rejects with `MCMailErrorDomain error 1030` when clicked. Example current output:

```
message:6333E88C-AEFA-4039-8CC9-B6FBBC987DDF%40andreadelis.com
```

Two issues:

- Scheme is `message:` instead of `message://`.
- The `@` is percent-encoded as `%40`, which Apple Mail does not accept.

AppleScript's `message id` property also returns the Message-ID with or without angle brackets depending on the sending client, so the helper must normalize both forms.

## Fix

In `_parse_search_records` (`plugin/apple_mail_mcp/tools/search.py`):

- Strip any existing angle brackets from the Message-ID.
- Rebuild the link with `message://` scheme, percent-encoded angle brackets, and raw `@`.

Resulting format:

```
message://%3C6333E88C-AEFA-4039-8CC9-B6FBBC987DDF@andreadelis.com%3E
```

This opens correctly in Apple Mail regardless of whether the source ID included angle brackets.

## Test plan

- [x] `python3 -m unittest discover tests` passes (11/11).
- [x] Updated two assertions in `tests/test_mail_search_tools.py` to reflect the new format.
- [x] Verified end-to-end by pasting the generated link into an Obsidian note and clicking it: Apple Mail opens the correct message. Verified against real emails whose Message-IDs are returned without angle brackets.