### PR TITLE
fix: respect account default sender and allow from_address override

### DIFF
--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -40,15 +40,19 @@ def _default_rich_draft_path(subject):
     return drafts_dir / (_safe_eml_name(subject) + ".eml")
 
 
-def _resolve_sender_address(account):
-    """Return the primary sender address for a Mail account, if available."""
+def _account_default_alias_if_single(account):
+    """Return the sole alias of `account` when it has exactly one configured
+    email address, else None. Used when no explicit sender is requested so
+    that single-address accounts still send from their own alias rather than
+    Mail's global "Send new messages from" preference.
+    """
     safe_account = escape_applescript(account)
     script = f'''
     tell application "Mail"
         try
             set targetAccount to account "{safe_account}"
             set emailAddrs to email addresses of targetAccount
-            if (count of emailAddrs) > 0 then
+            if (count of emailAddrs) is 1 then
                 return item 1 of emailAddrs
             end if
             return ""
@@ -57,9 +61,73 @@ def _resolve_sender_address(account):
         end try
     end tell
     '''
-    sender_address = run_applescript(script)
-    sender_address = sender_address.strip()
-    return sender_address or None
+    result = (run_applescript(script) or "").strip()
+    return result or None
+
+
+def _compose_sender_script(variable, account_ref, sender_override):
+    """Return AppleScript that sets the sender for a compose/reply/forward
+    outgoing message variable, respecting Mail's account-level defaults.
+
+    With `sender_override` the value is applied unconditionally. Without an
+    override, Mail's global composing preference may otherwise win over the
+    caller's account choice, so the sender is pinned to the account's only
+    alias when the account has a single address, and left untouched for
+    multi-alias accounts so the user's Mail preference stays in effect.
+    """
+    if sender_override:
+        safe_sender = escape_applescript(sender_override)
+        return f'set sender of {variable} to "{safe_sender}"'
+    return (
+        f"set emailAddrs to email addresses of {account_ref}\n"
+        f"if (count of emailAddrs) is 1 then\n"
+        f"    set sender of {variable} to item 1 of emailAddrs\n"
+        f"end if"
+    )
+
+
+def _validate_from_address(account, from_address):
+    """Return (validated_address, error_message) for a sender override.
+
+    When `from_address` is blank the override is skipped and both values
+    are None. Otherwise the candidate is matched case-insensitively
+    against the account's configured email addresses, and the original
+    casing from Mail is returned on success.
+    """
+    if from_address is None:
+        return None, None
+    candidate = from_address.strip()
+    if not candidate:
+        return None, None
+    safe_account = escape_applescript(account)
+    script = f'''
+    tell application "Mail"
+        try
+            set targetAccount to account "{safe_account}"
+            set emailAddrs to email addresses of targetAccount
+            set AppleScript's text item delimiters to linefeed
+            set addrText to emailAddrs as text
+            set AppleScript's text item delimiters to ""
+            return addrText
+        on error
+            return ""
+        end try
+    end tell
+    '''
+    raw = run_applescript(script) or ""
+    aliases = [line.strip() for line in raw.splitlines() if line.strip()]
+    if not aliases:
+        return None, (
+            f"Error: Could not read email addresses for account {account!r}."
+        )
+    lowered = {alias.lower(): alias for alias in aliases}
+    match = lowered.get(candidate.lower())
+    if not match:
+        return None, (
+            f"Error: 'from_address' {candidate!r} is not configured on account "
+            f"{account!r}. Known addresses: {', '.join(aliases)}"
+        )
+    return match, None
 
 
 def _build_html_from_text(text_body):
@@ -145,6 +213,7 @@ def create_rich_email_draft(
     output_path: Optional[str] = None,
     open_in_mail: bool = True,
     save_as_draft: bool = False,
+    from_address: Optional[str] = None,
 ) -> str:
     """
     Create a rich-text email draft by generating an unsent `.eml` message and optionally opening it in Mail.
@@ -163,12 +232,19 @@ def create_rich_email_draft(
         output_path: Optional path for the generated `.eml` file
         open_in_mail: If True, open the generated `.eml` in Mail (default: True)
         save_as_draft: If True, ask Mail to save the opened compose window into Drafts (default: False)
+        from_address: Optional sender address to stamp into the `.eml` `From:` header. Must be one of the account's configured email addresses. When omitted, Mail fills the account's default "Send new messages from" address on open.
 
     Returns:
         Confirmation with the generated `.eml` path, missing details, and Mail-open/save status
     """
     if not account or not account.strip():
         return "Error: 'account' is required"
+
+    sender_override, sender_error = _validate_from_address(account, from_address)
+    if sender_error:
+        return sender_error
+
+    sender_address = sender_override or _account_default_alias_if_single(account)
 
     recipients_to = _split_addresses(to)
     recipients_cc = _split_addresses(cc)
@@ -184,7 +260,6 @@ def create_rich_email_draft(
         missing_details.append("to")
     missing_details.extend(body_missing)
 
-    sender_address = _resolve_sender_address(account)
     message = EmailMessage()
     if subject:
         message["Subject"] = subject
@@ -251,6 +326,7 @@ def _send_html_email(
     bcc: Optional[str] = None,
     attachments_script: str = "",
     mode: str = "send",
+    sender_override: Optional[str] = None,
 ) -> str:
     """Send an HTML-formatted email via NSPasteboard clipboard injection.
 
@@ -275,6 +351,10 @@ def _send_html_email(
     if bcc:
         for addr in [a.strip() for a in bcc.split(",") if a.strip()]:
             bcc_lines += f'make new bcc recipient at end of bcc recipients with properties {{address:"{escape_applescript(addr)}"}}\n'
+
+    sender_script = _compose_sender_script(
+        "newMsg", f'account "{safe_account}"', sender_override
+    )
 
     # Mode-specific behaviour after paste
     if mode == "send":
@@ -328,9 +408,7 @@ pb's setData:htmlData forType:(current application's NSPasteboardTypeHTML)
 -- Step 2: Create compose window (empty body so signature doesn't interfere)
 tell application "Mail"
     set newMsg to make new outgoing message with properties {{subject:"{escaped_subject}", content:"", visible:true}}
-    set emailAddrs to email addresses of account "{safe_account}"
-    set senderAddress to item 1 of emailAddrs
-    set sender of newMsg to senderAddress
+    {sender_script}
     tell newMsg
         {to_lines}
         {cc_lines}
@@ -477,6 +555,7 @@ def reply_to_email(
     mode: Optional[str] = None,
     attachments: Optional[str] = None,
     body_html: Optional[str] = None,
+    from_address: Optional[str] = None,
 ) -> str:
     """
     Reply to an email matching a subject keyword.
@@ -492,10 +571,15 @@ def reply_to_email(
         mode: Delivery mode — "send" (send immediately), "draft" (save silently), or "open" (open compose window for review). Overrides send parameter when set.
         attachments: Optional file paths to attach, comma-separated for multiple (e.g., "/path/to/file1.png,/path/to/file2.pdf")
         body_html: Optional HTML body for rich formatting (bold, headings, links, colors). When provided, the reply is pasted as HTML. The plain 'reply_body' field is still required as fallback text.
+        from_address: Optional sender address to use for this reply. Must be one of the account's configured email addresses. When omitted, Mail uses the account's default "Send new messages from" setting.
 
     Returns:
         Confirmation message with details of the reply sent, saved draft, or opened draft
     """
+
+    sender_override, sender_error = _validate_from_address(account, from_address)
+    if sender_error:
+        return sender_error
 
     # Escape all user inputs for AppleScript
     safe_account = escape_applescript(account)
@@ -628,6 +712,10 @@ def reply_to_email(
     cleanup_script = f'do shell script "rm -f " & quoted form of "{body_temp_path}"'
     html_cleanup_script = f'do shell script "rm -f \'{html_temp_path}\'"'
 
+    sender_script = _compose_sender_script(
+        "replyMessage", "targetAccount", sender_override
+    )
+
     script = f'''
 use framework "Foundation"
 use framework "AppKit"
@@ -675,10 +763,7 @@ tell application "Mail"
             {reply_command}
             delay 0.5
 
-            -- Ensure the reply is from the correct account
-            set emailAddrs to email addresses of targetAccount
-            set senderAddress to item 1 of emailAddrs
-            set sender of replyMessage to senderAddress
+            {sender_script}
 
             -- Add CC/BCC recipients
             {cc_script}
@@ -783,6 +868,7 @@ def compose_email(
     attachments: Optional[str] = None,
     mode: str = "send",
     body_html: Optional[str] = None,
+    from_address: Optional[str] = None,
 ) -> str:
     """
     Compose and send a new email from a specific account.
@@ -797,6 +883,7 @@ def compose_email(
         attachments: Optional file paths to attach, comma-separated for multiple (e.g., "/path/to/file1.png,/path/to/file2.pdf")
         mode: Delivery mode — "send" (send immediately, default), "draft" (save silently to Drafts), or "open" (open compose window for review before sending)
         body_html: Optional HTML body for rich formatting (bold, headings, links, colors). When provided, the email is sent as HTML. The plain 'body' field is still required as fallback text.
+        from_address: Optional sender address to use for this message. Must be one of the account's configured email addresses. When omitted, Mail uses the account's default "Send new messages from" setting.
 
     Returns:
         Confirmation message with details of the email
@@ -805,6 +892,11 @@ def compose_email(
     # Validate mode
     if mode not in ("send", "draft", "open"):
         return f"Error: Invalid mode '{mode}'. Use: send, draft, open"
+
+    # Validate optional sender override
+    sender_override, sender_error = _validate_from_address(account, from_address)
+    if sender_error:
+        return sender_error
 
     # Validate and resolve attachments early
     attachment_script = ""
@@ -834,6 +926,7 @@ def compose_email(
             bcc=bcc,
             attachments_script=attachment_script,
             mode=mode,
+            sender_override=sender_override,
         )
 
     # --- Plain-text path: existing AppleScript approach ---
@@ -877,6 +970,10 @@ def compose_email(
         escape_applescript(attachment_info) if attachment_info else ""
     )
 
+    sender_script = _compose_sender_script(
+        "newMessage", "targetAccount", sender_override
+    )
+
     # Determine behavior per mode
     if mode == "send":
         header_text = "COMPOSING EMAIL"
@@ -904,10 +1001,7 @@ def compose_email(
             -- Create new outgoing message
             set newMessage to make new outgoing message with properties {{subject:"{escaped_subject}", content:"{escaped_body}", visible:{visible}}}
 
-            -- Set the sender account
-            set emailAddrs to email addresses of targetAccount
-            set senderAddress to item 1 of emailAddrs
-            set sender of newMessage to senderAddress
+            {sender_script}
 
             -- Add TO/CC/BCC recipients
             tell newMessage
@@ -968,6 +1062,7 @@ def forward_email(
     mailbox: str = "INBOX",
     cc: Optional[str] = None,
     bcc: Optional[str] = None,
+    from_address: Optional[str] = None,
 ) -> str:
     """
     Forward an email to one or more recipients.
@@ -980,10 +1075,15 @@ def forward_email(
         mailbox: Mailbox to search in (default: "INBOX")
         cc: Optional CC recipients, comma-separated for multiple
         bcc: Optional BCC recipients, comma-separated for multiple
+        from_address: Optional sender address to use when forwarding. Must be one of the account's configured email addresses. When omitted, Mail uses the account's default "Send new messages from" setting.
 
     Returns:
         Confirmation message with details of forwarded email
     """
+
+    sender_override, sender_error = _validate_from_address(account, from_address)
+    if sender_error:
+        return sender_error
 
     # Escape all user inputs for AppleScript
     safe_account = escape_applescript(account)
@@ -991,6 +1091,10 @@ def forward_email(
     safe_to = escape_applescript(to)
     safe_mailbox = escape_applescript(mailbox)
     escaped_message = escape_applescript(message) if message else ""
+
+    sender_script = _compose_sender_script(
+        "forwardMessage", "targetAccount", sender_override
+    )
 
     # Build CC recipients if provided
     cc_script = ""
@@ -1116,10 +1220,7 @@ tell application "Mail"
             -- Create forward
             set forwardMessage to forward foundMessage with opening window
 
-            -- Set sender account
-            set emailAddrs to email addresses of targetAccount
-            set senderAddress to item 1 of emailAddrs
-            set sender of forwardMessage to senderAddress
+            {sender_script}
 
             -- Add recipients
             {to_script}
@@ -1201,6 +1302,7 @@ def manage_drafts(
     cc: Optional[str] = None,
     bcc: Optional[str] = None,
     draft_subject: Optional[str] = None,
+    from_address: Optional[str] = None,
 ) -> str:
     """
     Manage draft emails - list, create, send, open, or delete drafts.
@@ -1214,6 +1316,7 @@ def manage_drafts(
         cc: Optional CC recipients for create
         bcc: Optional BCC recipients for create
         draft_subject: Subject keyword to find draft (required for send/open/delete)
+        from_address: Optional sender address for new drafts (action="create"). Must be one of the account's configured email addresses. When omitted, Mail uses the account's default "Send new messages from" setting.
 
     Returns:
         Formatted output based on action
@@ -1257,9 +1360,17 @@ def manage_drafts(
         if not subject or not to or not body:
             return "Error: 'subject', 'to', and 'body' are required for creating drafts"
 
+        sender_override, sender_error = _validate_from_address(account, from_address)
+        if sender_error:
+            return sender_error
+
         escaped_subject = escape_applescript(subject)
         escaped_body = escape_applescript(body)
         safe_to = escape_applescript(to)
+
+        sender_script = _compose_sender_script(
+            "newDraft", "targetAccount", sender_override
+        )
 
         # Build TO recipients (split comma-separated)
         to_script = ""
@@ -1300,10 +1411,7 @@ def manage_drafts(
                 -- Create new outgoing message (draft)
                 set newDraft to make new outgoing message with properties {{subject:"{escaped_subject}", content:"{escaped_body}", visible:false}}
 
-                -- Set the sender account
-                set emailAddrs to email addresses of targetAccount
-                set senderAddress to item 1 of emailAddrs
-                set sender of newDraft to senderAddress
+                {sender_script}
 
                 -- Add recipients
                 tell newDraft

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -3,9 +3,18 @@
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from apple_mail_mcp.tools import compose as compose_tools
+
+
+def _make_subprocess_result(returncode=0, stdout=b"", stderr=b""):
+    """Build a MagicMock shaped like subprocess.CompletedProcess."""
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
 
 
 class ComposeToolTests(unittest.TestCase):
@@ -334,6 +343,236 @@ class CreateRichEmailDraftFromAddressTests(unittest.TestCase):
 
             payload = output_path.read_text()
             self.assertIn("From: secondary@example.org", payload)
+
+
+class ReplyToEmailSenderOverrideTests(unittest.TestCase):
+    def test_default_emits_single_alias_fallback_for_reply_message(self):
+        with (
+            patch(
+                "apple_mail_mcp.tools.compose.subprocess.run",
+                return_value=_make_subprocess_result(),
+            ) as mock_run,
+            patch(
+                "apple_mail_mcp.tools.compose.run_applescript"
+            ) as mock_applescript,
+        ):
+            compose_tools.reply_to_email(
+                account="Work",
+                subject_keyword="test",
+                reply_body="Reply body",
+                send=False,
+            )
+
+        mock_applescript.assert_not_called()
+        script = mock_run.call_args.kwargs["input"].decode("utf-8")
+        self.assertIn("if (count of emailAddrs) is 1 then", script)
+        self.assertIn(
+            "set sender of replyMessage to item 1 of emailAddrs", script
+        )
+        self.assertNotIn('set sender of replyMessage to "', script)
+
+    def test_injects_sender_when_from_address_is_valid(self):
+        with (
+            patch(
+                "apple_mail_mcp.tools.compose.subprocess.run",
+                return_value=_make_subprocess_result(),
+            ) as mock_run,
+            patch(
+                "apple_mail_mcp.tools.compose.run_applescript",
+                return_value="default@example.com\nsecondary@example.org",
+            ),
+        ):
+            compose_tools.reply_to_email(
+                account="Work",
+                subject_keyword="test",
+                reply_body="Reply body",
+                from_address="secondary@example.org",
+                send=False,
+            )
+
+        script = mock_run.call_args.kwargs["input"].decode("utf-8")
+        self.assertIn(
+            'set sender of replyMessage to "secondary@example.org"', script
+        )
+        self.assertNotIn("if (count of emailAddrs) is 1 then", script)
+
+    def test_rejects_invalid_from_address_without_running_main_script(self):
+        with (
+            patch(
+                "apple_mail_mcp.tools.compose.subprocess.run"
+            ) as mock_run,
+            patch(
+                "apple_mail_mcp.tools.compose.run_applescript",
+                return_value="default@example.com",
+            ),
+        ):
+            result = compose_tools.reply_to_email(
+                account="Work",
+                subject_keyword="test",
+                reply_body="Reply body",
+                from_address="unknown@example.com",
+                send=False,
+            )
+
+        mock_run.assert_not_called()
+        self.assertTrue(result.startswith("Error: 'from_address'"))
+
+
+class ForwardEmailSenderOverrideTests(unittest.TestCase):
+    def test_default_emits_single_alias_fallback_for_forward_message(self):
+        captured = []
+
+        def fake_run(script, timeout=120):
+            captured.append(script)
+            return "✓ Forwarded"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            compose_tools.forward_email(
+                account="Work",
+                subject_keyword="test",
+                to="recipient@example.com",
+            )
+
+        self.assertEqual(len(captured), 1)
+        script = captured[0]
+        self.assertIn("if (count of emailAddrs) is 1 then", script)
+        self.assertIn(
+            "set sender of forwardMessage to item 1 of emailAddrs", script
+        )
+        self.assertNotIn('set sender of forwardMessage to "', script)
+
+    def test_injects_sender_when_from_address_is_valid(self):
+        scripts = []
+
+        def fake_run(script, timeout=120):
+            scripts.append(script)
+            if len(scripts) == 1:
+                return "default@example.com\nsecondary@example.org"
+            return "✓ Forwarded"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            compose_tools.forward_email(
+                account="Work",
+                subject_keyword="test",
+                to="recipient@example.com",
+                from_address="secondary@example.org",
+            )
+
+        self.assertEqual(len(scripts), 2)
+        main_script = scripts[1]
+        self.assertIn(
+            'set sender of forwardMessage to "secondary@example.org"',
+            main_script,
+        )
+        self.assertNotIn("if (count of emailAddrs) is 1 then", main_script)
+
+    def test_rejects_invalid_from_address_without_running_main_script(self):
+        scripts = []
+
+        def fake_run(script, timeout=120):
+            scripts.append(script)
+            return "default@example.com"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            result = compose_tools.forward_email(
+                account="Work",
+                subject_keyword="test",
+                to="recipient@example.com",
+                from_address="unknown@example.com",
+            )
+
+        self.assertEqual(len(scripts), 1)
+        self.assertTrue(result.startswith("Error: 'from_address'"))
+
+
+class ManageDraftsCreateSenderOverrideTests(unittest.TestCase):
+    def test_default_emits_single_alias_fallback_for_new_draft(self):
+        captured = []
+
+        def fake_run(script, timeout=120):
+            captured.append(script)
+            return "✓ Draft created"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            compose_tools.manage_drafts(
+                account="Work",
+                action="create",
+                subject="Draft",
+                to="recipient@example.com",
+                body="Body",
+            )
+
+        self.assertEqual(len(captured), 1)
+        script = captured[0]
+        self.assertIn("if (count of emailAddrs) is 1 then", script)
+        self.assertIn(
+            "set sender of newDraft to item 1 of emailAddrs", script
+        )
+        self.assertNotIn('set sender of newDraft to "', script)
+
+    def test_injects_sender_when_from_address_is_valid(self):
+        scripts = []
+
+        def fake_run(script, timeout=120):
+            scripts.append(script)
+            if len(scripts) == 1:
+                return "default@example.com\nsecondary@example.org"
+            return "✓ Draft created"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            compose_tools.manage_drafts(
+                account="Work",
+                action="create",
+                subject="Draft",
+                to="recipient@example.com",
+                body="Body",
+                from_address="secondary@example.org",
+            )
+
+        self.assertEqual(len(scripts), 2)
+        main_script = scripts[1]
+        self.assertIn(
+            'set sender of newDraft to "secondary@example.org"', main_script
+        )
+        self.assertNotIn("if (count of emailAddrs) is 1 then", main_script)
+
+    def test_rejects_invalid_from_address_without_running_main_script(self):
+        scripts = []
+
+        def fake_run(script, timeout=120):
+            scripts.append(script)
+            return "default@example.com"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            result = compose_tools.manage_drafts(
+                account="Work",
+                action="create",
+                subject="Draft",
+                to="recipient@example.com",
+                body="Body",
+                from_address="unknown@example.com",
+            )
+
+        self.assertEqual(len(scripts), 1)
+        self.assertTrue(result.startswith("Error: 'from_address'"))
 
 
 if __name__ == "__main__":

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -87,5 +87,254 @@ class ComposeToolTests(unittest.TestCase):
             self.assertIn("Saved in Drafts: yes", result)
 
 
+class ValidateFromAddressTests(unittest.TestCase):
+    def test_none_skips_lookup(self):
+        with patch("apple_mail_mcp.tools.compose.run_applescript") as mock_run:
+            override, error = compose_tools._validate_from_address("Work", None)
+        self.assertIsNone(override)
+        self.assertIsNone(error)
+        mock_run.assert_not_called()
+
+    def test_blank_skips_lookup(self):
+        with patch("apple_mail_mcp.tools.compose.run_applescript") as mock_run:
+            override, error = compose_tools._validate_from_address("Work", "   ")
+        self.assertIsNone(override)
+        self.assertIsNone(error)
+        mock_run.assert_not_called()
+
+    def test_matches_case_insensitively_and_trims(self):
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            return_value="Default@Example.com\nSecondary@Example.org",
+        ):
+            override, error = compose_tools._validate_from_address(
+                "Work", "  SECONDARY@example.ORG "
+            )
+        self.assertEqual(override, "Secondary@Example.org")
+        self.assertIsNone(error)
+
+    def test_unknown_alias_returns_error(self):
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            return_value="default@example.com",
+        ):
+            override, error = compose_tools._validate_from_address(
+                "Work", "other@example.com"
+            )
+        self.assertIsNone(override)
+        self.assertIn("is not configured on account", error)
+        self.assertIn("default@example.com", error)
+
+    def test_missing_aliases_returns_error(self):
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            return_value="",
+        ):
+            override, error = compose_tools._validate_from_address(
+                "Work", "anything@example.com"
+            )
+        self.assertIsNone(override)
+        self.assertIn("Could not read email addresses", error)
+
+
+class ComposeEmailSenderOverrideTests(unittest.TestCase):
+    def test_default_emits_single_alias_fallback_block(self):
+        captured = []
+
+        def fake_run(script, timeout=120):
+            captured.append(script)
+            return "✓ Email sent successfully!"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            compose_tools.compose_email(
+                account="Work",
+                to="self@example.com",
+                subject="Test",
+                body="Body",
+                mode="draft",
+            )
+
+        self.assertEqual(len(captured), 1)
+        script = captured[0]
+        self.assertIn("email addresses of targetAccount", script)
+        self.assertIn("if (count of emailAddrs) is 1 then", script)
+        self.assertIn(
+            "set sender of newMessage to item 1 of emailAddrs", script
+        )
+        self.assertNotIn('set sender of newMessage to "', script)
+
+    def test_injects_sender_when_from_address_is_valid(self):
+        scripts = []
+
+        def fake_run(script, timeout=120):
+            scripts.append(script)
+            if len(scripts) == 1:
+                return "default@example.com\nsecondary@example.org"
+            return "✓ Email sent successfully!"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            compose_tools.compose_email(
+                account="Work",
+                to="self@example.com",
+                subject="Test",
+                body="Body",
+                mode="draft",
+                from_address="secondary@example.org",
+            )
+
+        self.assertEqual(len(scripts), 2)
+        main_script = scripts[1]
+        self.assertIn(
+            'set sender of newMessage to "secondary@example.org"', main_script
+        )
+        self.assertNotIn("if (count of emailAddrs) is 1 then", main_script)
+
+    def test_rejects_invalid_from_address_without_sending(self):
+        scripts = []
+
+        def fake_run(script, timeout=120):
+            scripts.append(script)
+            return "default@example.com"
+
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            side_effect=fake_run,
+        ):
+            result = compose_tools.compose_email(
+                account="Work",
+                to="self@example.com",
+                subject="Test",
+                body="Body",
+                mode="draft",
+                from_address="unknown@example.com",
+            )
+
+        self.assertEqual(len(scripts), 1)
+        self.assertTrue(result.startswith("Error: 'from_address'"))
+
+
+class AccountDefaultAliasIfSingleTests(unittest.TestCase):
+    def test_returns_sole_alias(self):
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            return_value="solo@example.com",
+        ):
+            self.assertEqual(
+                compose_tools._account_default_alias_if_single("Solo"),
+                "solo@example.com",
+            )
+
+    def test_returns_none_when_empty(self):
+        with patch(
+            "apple_mail_mcp.tools.compose.run_applescript",
+            return_value="",
+        ):
+            self.assertIsNone(
+                compose_tools._account_default_alias_if_single("Multi")
+            )
+
+
+class ComposeSenderScriptTests(unittest.TestCase):
+    def test_override_sets_sender_directly(self):
+        script = compose_tools._compose_sender_script(
+            "newMessage", "targetAccount", "chosen@example.com"
+        )
+        self.assertEqual(
+            script, 'set sender of newMessage to "chosen@example.com"'
+        )
+
+    def test_without_override_emits_single_alias_fallback(self):
+        script = compose_tools._compose_sender_script(
+            "newMessage", "targetAccount", None
+        )
+        self.assertIn("email addresses of targetAccount", script)
+        self.assertIn("if (count of emailAddrs) is 1 then", script)
+        self.assertIn(
+            "set sender of newMessage to item 1 of emailAddrs", script
+        )
+
+    def test_override_value_is_escaped(self):
+        script = compose_tools._compose_sender_script(
+            "newMessage", "targetAccount", 'weird"quote@example.com'
+        )
+        self.assertIn(r'\"quote@example.com', script)
+
+
+class CreateRichEmailDraftFromAddressTests(unittest.TestCase):
+    def test_omits_from_header_for_multi_alias_account(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "multi.eml"
+            with (
+                patch(
+                    "apple_mail_mcp.tools.compose.run_applescript",
+                    return_value="",
+                ),
+                patch("apple_mail_mcp.tools.compose.subprocess.run"),
+            ):
+                compose_tools.create_rich_email_draft(
+                    account="Multi",
+                    subject="No From",
+                    to="team@example.com",
+                    text_body="Body",
+                    output_path=str(output_path),
+                    open_in_mail=False,
+                )
+
+            payload = output_path.read_text()
+            header_block = payload.split("\n\n", 1)[0]
+            self.assertNotIn("From:", header_block)
+
+    def test_stamps_from_header_for_single_alias_account(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "single.eml"
+            with (
+                patch(
+                    "apple_mail_mcp.tools.compose.run_applescript",
+                    return_value="solo@example.com",
+                ),
+                patch("apple_mail_mcp.tools.compose.subprocess.run"),
+            ):
+                compose_tools.create_rich_email_draft(
+                    account="Solo",
+                    subject="Single",
+                    to="team@example.com",
+                    text_body="Body",
+                    output_path=str(output_path),
+                    open_in_mail=False,
+                )
+
+            payload = output_path.read_text()
+            self.assertIn("From: solo@example.com", payload)
+
+    def test_stamps_from_header_when_address_is_valid(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "stamped.eml"
+            with (
+                patch(
+                    "apple_mail_mcp.tools.compose.run_applescript",
+                    return_value="default@example.com\nsecondary@example.org",
+                ),
+                patch("apple_mail_mcp.tools.compose.subprocess.run"),
+            ):
+                compose_tools.create_rich_email_draft(
+                    account="Work",
+                    subject="Stamped",
+                    to="team@example.com",
+                    text_body="Body",
+                    output_path=str(output_path),
+                    open_in_mail=False,
+                    from_address="secondary@example.org",
+                )
+
+            payload = output_path.read_text()
+            self.assertIn("From: secondary@example.org", payload)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

On Mail accounts with multiple aliases, the send/reply/forward/draft tools send outgoing mail from the wrong alias. They use whichever alias happens to be first in AppleScript's array, not the one the user has set as the account's default in "Send new messages from". Callers also have no way to pick a specific alias for a given message, since none of the send tools expose a sender parameter.

The root cause is in `plugin/apple_mail_mcp/tools/compose.py`. Five AppleScript sites hardcode this:

```applescript
set emailAddrs to email addresses of targetAccount
set senderAddress to item 1 of emailAddrs
set sender of <msg> to senderAddress
```

The `_resolve_sender_address` helper does the same thing for the `From:` header on `.eml` drafts generated by `create_rich_email_draft`.

Example: an iCloud account with `default@example.com` (set as the Mail default), `secondary@example2.com`, and `extra@example3.com`. Today, `compose_email(account="iCloud", ...)` sends from whichever alias happens to be `item 1`, not from `default@example.com`.

## Fix

Removing the forced `set sender` altogether regresses single-address accounts. Without a forced sender, Mail falls back to the global "Send new messages from" preference, which often differs from a secondary account's only address. So the fix is hybrid.

Behavior without `from_address`:

- Single-alias account: pin sender to the sole alias, preserving the old correct behavior.
- Multi-alias account: do not force a sender, let Mail apply the account's configured default.

Behavior with `from_address`: use the provided alias after validating it against the account's aliases. Matching is case-insensitive with whitespace trimmed. If the address is not one of the account's aliases, the call returns an error listing the known aliases and no outgoing script runs.

Three new helpers in `compose.py`:

- `_account_default_alias_if_single` returns the sole alias of an account, or `None`.
- `_compose_sender_script` emits the AppleScript for the rules above.
- `_validate_from_address` validates the optional override.

Affected tools, each gaining an optional `from_address` parameter: `compose_email` (plain and HTML), `reply_to_email`, `forward_email`, `create_rich_email_draft`, and `manage_drafts` with `action="create"`.

Behavior with the same example account:

- `compose_email(...)` sends from `default@example.com`.
- `compose_email(..., from_address="secondary@example2.com")` sends from `secondary@example2.com`.
- `compose_email(..., from_address="unknown@example.org")` returns `Error: 'from_address' 'unknown@example.org' is not configured on account 'iCloud'. Known addresses: default@example.com, secondary@example2.com, extra@example3.com` and does not send.

## Test plan

- [x] `python -m unittest discover tests` passes (28/28, 16 new).
- [x] Unit tests cover the two new helpers and the validation paths for the override parameter. They also check that the generated AppleScript uses the correct sender-script variant per call site, and that `.eml` drafts stamp or omit `From:` according to the rules above.
- [x] Verified end-to-end against real Mail on a multi-alias iCloud account. With no `from_address`, the sent message goes out from the account's configured default. With `from_address` set to a different alias, the sent message goes out from that alias. Test messages deleted after each assertion.