### PR TITLE
fix: work around orphaned server keeping Mail alive (python-sdk#526)

### DIFF
--- a/plugin/apple_mail_mcp/__main__.py
+++ b/plugin/apple_mail_mcp/__main__.py
@@ -1,11 +1,33 @@
 """Entry point for `python -m apple_mail_mcp` and `apple-mail-mcp` CLI."""
 
 import argparse
+import os
+import threading
+import time
 
 import apple_mail_mcp.server as server
 
 
+# When the MCP client (e.g. Claude) exits without closing stdin
+# cleanly, the FastMCP server can keep running orphaned in the background
+# (see modelcontextprotocol/python-sdk#526). The orphaned server keeps
+# polling Mail.app via Apple Events, which causes Mail to relaunch after
+# the user quits it. Detect the orphan state (PPID reparented to launchd)
+# and self-terminate. Uses os._exit because sys.exit does not tear down
+# FastMCP's background asyncio loop reliably.
+def _start_orphan_watcher(interval_sec: int = 10) -> None:
+    def _watch() -> None:
+        while True:
+            if os.getppid() < 100:
+                os._exit(0)
+            time.sleep(interval_sec)
+
+    threading.Thread(target=_watch, daemon=True).start()
+
+
 def main():
+    _start_orphan_watcher()
+
     parser = argparse.ArgumentParser(description="Apple Mail MCP Server")
     parser.add_argument(
         "--read-only",


### PR DESCRIPTION
## Problem

When Claude exits without cleanly closing the stdio pipe to the MCP server, the FastMCP server can keep running orphaned (PPID reparented to launchd). The orphan keeps polling Mail.app via Apple Events, so Mail relaunches automatically each time the user quits it. Root cause is upstream in the MCP Python SDK, tracked as modelcontextprotocol/python-sdk#526 (open since April 2025).

Symptoms:

- User force-quits Mail
- Mail reopens within seconds, repeatedly
- `pgrep -af apple_mail_mcp.py` shows processes with PPID=1 and elapsed time far exceeding the active Claude session

## Workaround

Start a daemon thread in `__main__.py` that checks `os.getppid()` every 10 seconds and calls `os._exit(0)` when the parent has been reparented to launchd (PPID < 100). Uses `os._exit` because `sys.exit` does not reliably tear down FastMCP's background asyncio loop (confirmed in the upstream issue comments).

Defensive measure only. The proper fix belongs in the Python SDK. This can be reverted once modelcontextprotocol/python-sdk#526 is resolved.

## Test plan

- [x] Existing suite passes: `python3 -m unittest discover -s tests` → 12/12
- [x] Watcher logic verified in isolation: parent spawns child and exits, child detects PPID=1 on first tick and calls `os._exit(0)`
- [x] MCP handshake still works with the watcher running: `initialize` succeeds, `tools/list` returns 24 tools as before
- [x] Live end-to-end repro: orphaned child polls Mail.app via Apple Events every 5s. While polling, Mail relaunches automatically after force-quit. After the watcher fires, polling stops and Mail stays closed.

Refs: modelcontextprotocol/python-sdk#526