### PR TITLE
chore: bump version to 3.1.2 for PyPI release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "apple-mail",
       "source": "./plugin",
       "description": "Natural language interface for Apple Mail — search, compose, triage, organize, and analyze email with 24 MCP tools and an expert email management skill",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "author": {
         "name": "Patrick Freyer"
       }

--- a/apple-mail-mcpb/manifest.json
+++ b/apple-mail-mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "Apple Mail MCP",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "description": "Natural language interface for Apple Mail with 27 tools — email search, composition, bulk operations, smart inbox analytics, folder management, and security-hardened destructive operations. Includes Email Management Expert Skill and Interactive UI Dashboard.",
   "author": {
     "name": "Patrick Freyer"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-mail",
   "description": "Natural language interface for Apple Mail — search, compose, triage, organize, and analyze email with 24 MCP tools and an expert email management skill",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "author": {
     "name": "Patrick Freyer",
     "email": "freyer.patrick@bcg.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-apple-mail"
-version = "3.1.0"
+version = "3.1.2"
 description = "MCP server giving AI assistants full access to Apple Mail - read, search, compose, organize & analyze emails"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/patrickfreyer/apple-mail-mcp",
     "source": "github"
   },
-  "version": "3.1.0",
+  "version": "3.1.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-apple-mail",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Bumps version 3.1.0 → 3.1.2 across `pyproject.toml`, `server.json`, `plugin/.claude-plugin/plugin.json`, `apple-mail-mcpb/manifest.json`, `.claude-plugin/marketplace.json`
- Resolves #38 — the only PyPI release is 2.2.0, which fails with `ModuleNotFoundError: No module named 'apple_mail_mcp'` because it predates the `plugin/` layout move
- v3.1.0 and v3.1.1 git tags exist but were never published; jumping to 3.1.2 to give us a clean PyPI version that includes everything on main

## What's in 3.1.2 (vs the broken 2.2.0 on PyPI)
- Layout fix: `plugin/apple_mail_mcp/` packaging (commit 573fbe2)
- `mcp-name` verification string (54257ab)
- `server.json` for MCP Registry (1f0fd86)
- Mail relaunch loop workaround / orphan watcher (#37, cd8d9e9)

## Release plan after merge
1. Tag v3.1.2 on the merge commit
2. `python -m build`
3. Local verify: `uvx --from ./dist/mcp_apple_mail-3.1.2-py3-none-any.whl mcp-apple-mail --help`
4. `twine upload`
5. Verify from PyPI: `uvx mcp-apple-mail==3.1.2 --help`
6. Close #38

## Test plan
- [x] All 14 tests pass on this branch (`python -m unittest discover -s tests`)
- [ ] Local wheel boots cleanly via `uvx`
- [ ] PyPI install succeeds after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)