### PR TITLE
Add list_account_addresses tool

### DIFF
--- a/plugin/apple_mail_mcp/tools/inbox.py
+++ b/plugin/apple_mail_mcp/tools/inbox.py
@@ -352,6 +352,62 @@ def list_accounts() -> List[str]:
 
 @mcp.tool()
 @inject_preferences
+def list_account_addresses() -> Dict[str, List[str]]:
+    """
+    List all configured email addresses for each Mail account.
+
+    Useful for mapping a Mail.app account name (e.g. "Gmail", "Work") to the
+    actual email address(es) it receives mail at — handy when an integration
+    needs to know which inbox a message landed in by address rather than by
+    Mail.app's display name.
+
+    Returns:
+        Dict mapping account name -> list of email addresses configured on
+        that account. Accounts with no addresses configured map to [].
+    """
+
+    script = """
+    tell application "Mail"
+        set outLines to {}
+        set allAccounts to every account
+
+        repeat with anAccount in allAccounts
+            set acctName to name of anAccount
+            try
+                set emailAddrs to email addresses of anAccount
+            on error
+                set emailAddrs to {}
+            end try
+            if emailAddrs is missing value then
+                set emailAddrs to {}
+            end if
+            set AppleScript's text item delimiters to ","
+            set addrStr to emailAddrs as string
+            set AppleScript's text item delimiters to ""
+            set end of outLines to acctName & "|" & addrStr
+        end repeat
+
+        set AppleScript's text item delimiters to linefeed
+        set joined to outLines as string
+        set AppleScript's text item delimiters to ""
+        return joined
+    end tell
+    """
+
+    result = run_applescript(script)
+    out: Dict[str, List[str]] = {}
+    if not result:
+        return out
+    for line in result.splitlines():
+        if "|" not in line:
+            continue
+        name, addrs = line.split("|", 1)
+        out[name] = [a.strip() for a in addrs.split(",") if a.strip()]
+    return out
+
+
+@mcp.tool()
+@inject_preferences
 def list_mailboxes(account: Optional[str] = None, include_counts: bool = True) -> str:
     """
     List all mailboxes (folders) for a specific account or all accounts.


### PR DESCRIPTION
## Summary

Adds a small new tool `list_account_addresses` that returns each Mail.app account's configured email address(es).

`list_accounts` returns just account names, which is the user-chosen Mail.app display name (e.g. "Work", "iCloud") and not necessarily the receiving address. Downstream integrations that want to map an inbound message to its actual receiving inbox (e.g. for routing, filtering, or display) need a way to ask Mail.app for the addresses configured on each account. AppleScript exposes this directly via `email addresses of <account>`.

## Test plan

- [ ] Call the tool on a Mac with multiple Mail accounts; confirm each account name maps to its configured address list
- [ ] Confirm accounts with no addresses map to `[]`
- [ ] Confirm output remains stable when account names contain pipes or commas (we delimit with `|` between name and addresses, `,` between addresses; AppleScript text item delimiters are reset between fields)