### PR TITLE
feat: show mail_link in default text search output

### DIFF
--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -122,6 +122,8 @@ def _format_search_records_text(
             lines.append(f"   From: {item['sender']}")
             lines.append(f"   Date: {item['received_date']}")
             lines.append(f"   Mailbox: {item['mailbox']}")
+            if item.get("mail_link"):
+                lines.append(f"   Link: {item['mail_link']}")
             if item.get("content_preview"):
                 lines.append(f"   Content: {item['content_preview']}")
             lines.append("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-apple-mail"
-version = "3.1.2"
+version = "3.1.3"
 description = "MCP server giving AI assistants full access to Apple Mail - read, search, compose, organize & analyze emails"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- The `message://` deep link (`mail_link`) was already computed and included in JSON search output, but omitted from the default text format
- Added `Link:` line to text output so users can see and copy the deep link directly
- Bumped version to 3.1.3

Addresses a user request to expose email Message-IDs as pasteable Apple Reminders URLs.

## Test plan
- [x] Verified `mail_link` already present in JSON output
- [x] Confirmed text output now includes `Link:` field when `mail_link` exists
- [x] Version bumped in pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)