### PR TITLE
Add get_email_attachment + surface attachment metadata in get_email_message

### DIFF
--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -739,3 +739,184 @@ def get_email_thread(
 
     result = run_applescript(script)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Single-message rich-content fetch.
+# Used by Sane's email detail view to surface HTML body + To/Cc/Bcc on demand
+# without bloating every search response. Walks the raw RFC822 source through
+# Python's email module so newsletter-style HTML, encoded recipient lists,
+# and multipart structures all parse correctly.
+# ---------------------------------------------------------------------------
+
+
+def _decode_payload(part) -> str:
+    """Best-effort string decode of one MIME part (handles charset + b64/qp)."""
+    payload = part.get_payload(decode=True)
+    if payload is None:
+        # Fallback: get_payload(decode=False) when the part is a string already
+        return str(part.get_payload() or "")
+    charset = part.get_content_charset() or "utf-8"
+    try:
+        return payload.decode(charset, errors="replace")
+    except (LookupError, AttributeError):
+        return payload.decode("utf-8", errors="replace")
+
+
+def _split_addresses(value: Optional[str]) -> List[str]:
+    """Parse an RFC822 address list into normalized 'Name <addr>' strings."""
+    if not value:
+        return []
+    import email.utils
+
+    parsed = email.utils.getaddresses([value])
+    out: List[str] = []
+    for name, addr in parsed:
+        if not addr:
+            continue
+        addr = addr.strip()
+        if name:
+            out.append(f'"{name.strip()}" <{addr}>')
+        else:
+            out.append(addr)
+    return out
+
+
+def _decode_header_value(value: Optional[str]) -> str:
+    """Decode RFC2047-encoded header to a plain string."""
+    if not value:
+        return ""
+    import email.header
+
+    parts = email.header.decode_header(value)
+    out = []
+    for chunk, charset in parts:
+        if isinstance(chunk, bytes):
+            try:
+                out.append(chunk.decode(charset or "utf-8", errors="replace"))
+            except LookupError:
+                out.append(chunk.decode("utf-8", errors="replace"))
+        else:
+            out.append(chunk)
+    return "".join(out)
+
+
+@mcp.tool()
+@inject_preferences
+def get_email_message(
+    account: str,
+    message_id: str,
+    mailbox: str = "INBOX",
+) -> str:
+    """
+    Return one email's full body (text + HTML when available) and recipients.
+
+    Heavier than search_emails — it pulls the raw RFC822 source from Mail.app
+    via AppleScript, then parses MIME in Python. Use it on demand when a UI
+    needs to render the rich body or surface Cc/Bcc lists; do not call it
+    inside a poll loop.
+
+    Args:
+        account: Account name (e.g. "Gmail")
+        message_id: Apple Mail's numeric `id of message` (the same value
+            search_emails returns as `message_id`)
+        mailbox: Mailbox to look in (default "INBOX")
+
+    Returns:
+        JSON string with keys:
+          subject, sender, date, message_id,
+          to_recipients, cc_recipients, bcc_recipients,
+          content_text, content_html, has_html
+    """
+    escaped_account = escape_applescript(account)
+    escaped_mailbox = escape_applescript(mailbox)
+    escaped_id = escape_applescript(str(message_id))
+
+    # First try the recorded mailbox; if the message has been moved (or
+    # archived to All Mail / a custom folder) the user still expects the
+    # detail panel to render, so fall back to scanning every mailbox in
+    # the account before reporting not_found.
+    script = f'''
+    tell application "Mail"
+        try
+            set targetAccount to account "{escaped_account}"
+            try
+                set targetMailbox to mailbox "{escaped_mailbox}" of targetAccount
+                set matches to (every message of targetMailbox whose id is ({escaped_id} as integer))
+                if (count of matches) > 0 then
+                    return source of (item 1 of matches)
+                end if
+            end try
+            -- Fallback: scan every mailbox of the account.
+            repeat with aMailbox in (every mailbox of targetAccount)
+                try
+                    set m to (every message of aMailbox whose id is ({escaped_id} as integer))
+                    if (count of m) > 0 then
+                        return source of (item 1 of m)
+                    end if
+                end try
+            end repeat
+            return "ERROR|||not_found"
+        on error errMsg
+            return "ERROR|||" & errMsg
+        end try
+    end tell
+    '''
+
+    raw = run_applescript(script, timeout=180)
+    if raw.startswith("ERROR|||"):
+        return json.dumps({"error": raw[8:].strip() or "applescript_error"})
+
+    import email as email_mod
+
+    msg = email_mod.message_from_string(raw)
+
+    text_body = ""
+    html_body = ""
+    if msg.is_multipart():
+        # Walk all parts; pick the longest text/* of each kind so nested
+        # multipart/alternative layouts don't accidentally surface a one-line
+        # auto-reply over the real body.
+        for part in msg.walk():
+            ctype = part.get_content_type()
+            if part.get_content_maintype() == "multipart":
+                continue
+            try:
+                body = _decode_payload(part)
+            except Exception:
+                continue
+            if ctype == "text/html" and len(body) > len(html_body):
+                html_body = body
+            elif ctype == "text/plain" and len(body) > len(text_body):
+                text_body = body
+    else:
+        try:
+            body = _decode_payload(msg)
+        except Exception:
+            body = ""
+        if msg.get_content_type() == "text/html":
+            html_body = body
+        else:
+            text_body = body
+
+    return json.dumps(
+        {
+            "subject": _decode_header_value(msg.get("Subject")),
+            "sender": _decode_header_value(msg.get("From")),
+            "date": _decode_header_value(msg.get("Date")),
+            "message_id": _decode_header_value(msg.get("Message-ID"))
+            or _decode_header_value(msg.get("Message-Id")),
+            "to_recipients": _split_addresses(_decode_header_value(msg.get("To"))),
+            "cc_recipients": _split_addresses(_decode_header_value(msg.get("Cc"))),
+            "bcc_recipients": _split_addresses(_decode_header_value(msg.get("Bcc"))),
+            "content_text": _sanitize_text(text_body),
+            "content_html": html_body,
+            "has_html": bool(html_body),
+        },
+        ensure_ascii=False,
+    )
+
+
+def _sanitize_text(s: str) -> str:
+    """Strip object replacement characters Mail substitutes for inline media."""
+    return s.replace("￼", "").replace("​", "").strip()

--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -873,13 +873,36 @@ def get_email_message(
 
     text_body = ""
     html_body = ""
+    attachments: List[Dict[str, Any]] = []
     if msg.is_multipart():
         # Walk all parts; pick the longest text/* of each kind so nested
         # multipart/alternative layouts don't accidentally surface a one-line
-        # auto-reply over the real body.
+        # auto-reply over the real body. Anything with a filename or an
+        # explicit attachment disposition gets surfaced separately so
+        # callers can render a download list.
+        idx = 0
         for part in msg.walk():
             ctype = part.get_content_type()
             if part.get_content_maintype() == "multipart":
+                continue
+            disposition = (part.get("Content-Disposition") or "").lower()
+            filename = part.get_filename()
+            is_attachment = bool(filename) or "attachment" in disposition
+            if is_attachment:
+                try:
+                    payload = part.get_payload(decode=True) or b""
+                except Exception:
+                    payload = b""
+                attachments.append(
+                    {
+                        "index": idx,
+                        "filename": _decode_header_value(filename) or f"attachment-{idx + 1}",
+                        "content_type": ctype,
+                        "size": len(payload),
+                        "is_inline": "inline" in disposition,
+                    }
+                )
+                idx += 1
                 continue
             try:
                 body = _decode_payload(part)
@@ -912,9 +935,116 @@ def get_email_message(
             "content_text": _sanitize_text(text_body),
             "content_html": html_body,
             "has_html": bool(html_body),
+            "attachments": attachments,
         },
         ensure_ascii=False,
     )
+
+
+@mcp.tool()
+@inject_preferences
+def get_email_attachment(
+    account: str,
+    message_id: str,
+    attachment_index: int,
+    mailbox: str = "INBOX",
+) -> str:
+    """
+    Return one attachment from a message as base64-encoded bytes.
+
+    Pair with get_email_message — the attachments array there exposes
+    each part's `index`, `filename`, `content_type`, and `size`. Pass
+    that index back here to fetch the bytes for download or inline
+    rendering. Wire transport is JSON, so the payload is base64; the
+    caller decodes.
+
+    Args:
+        account: Account name (e.g. "Gmail").
+        message_id: Apple Mail's numeric `id of message`.
+        attachment_index: Zero-based index from get_email_message's
+            `attachments` array.
+        mailbox: Mailbox to look in (default "INBOX"). Falls back to
+            scanning every mailbox of the account, mirroring
+            get_email_message's behaviour.
+
+    Returns:
+        JSON string {filename, content_type, size, content_base64}
+        or {error: "<reason>"} on failure.
+    """
+    import base64
+
+    escaped_account = escape_applescript(account)
+    escaped_mailbox = escape_applescript(mailbox)
+    escaped_id = escape_applescript(str(message_id))
+
+    script = f'''
+    tell application "Mail"
+        try
+            set targetAccount to account "{escaped_account}"
+            try
+                set targetMailbox to mailbox "{escaped_mailbox}" of targetAccount
+                set matches to (every message of targetMailbox whose id is ({escaped_id} as integer))
+                if (count of matches) > 0 then
+                    return source of (item 1 of matches)
+                end if
+            end try
+            repeat with aMailbox in (every mailbox of targetAccount)
+                try
+                    set m to (every message of aMailbox whose id is ({escaped_id} as integer))
+                    if (count of m) > 0 then
+                        return source of (item 1 of m)
+                    end if
+                end try
+            end repeat
+            return "ERROR|||not_found"
+        on error errMsg
+            return "ERROR|||" & errMsg
+        end try
+    end tell
+    '''
+    raw = run_applescript(script, timeout=180)
+    if raw.startswith("ERROR|||"):
+        return json.dumps({"error": raw[8:].strip() or "applescript_error"})
+
+    import email as email_mod
+
+    msg = email_mod.message_from_string(raw)
+
+    if not msg.is_multipart():
+        return json.dumps({"error": "no_attachments"})
+
+    idx = 0
+    for part in msg.walk():
+        if part.get_content_maintype() == "multipart":
+            continue
+        disposition = (part.get("Content-Disposition") or "").lower()
+        filename = part.get_filename()
+        is_attachment = bool(filename) or "attachment" in disposition
+        if not is_attachment:
+            continue
+        if idx == attachment_index:
+            try:
+                raw_payload = part.get_payload(decode=True)
+                if isinstance(raw_payload, bytearray):
+                    payload: bytes = bytes(raw_payload)
+                elif isinstance(raw_payload, bytes):
+                    payload = raw_payload
+                else:
+                    payload = b""
+            except Exception as e:
+                return json.dumps({"error": f"decode_failed: {e}"})
+            return json.dumps(
+                {
+                    "filename": _decode_header_value(filename)
+                    or f"attachment-{idx + 1}",
+                    "content_type": part.get_content_type(),
+                    "size": len(payload),
+                    "content_base64": base64.b64encode(payload).decode("ascii"),
+                }
+            )
+        idx += 1
+
+    return json.dumps({"error": "index_out_of_range"})
 
 
 def _sanitize_text(s: str) -> str:


### PR DESCRIPTION
Stacks on top of #48. Once that lands the diff narrows to just the new tool.

## Summary

- **\`get_email_message\` now returns attachment metadata.** The MIME-walking branch already had the parts in hand; it now also collects \`attachments: [{index, filename, content_type, size, is_inline}]\`. Body extraction is unchanged — anything with a filename or an attachment-disposition header is treated as an attachment regardless of content type, so PDFs without filenames still surface, while \`text/plain\` and \`text/html\` parts continue to feed the body fields.

- **New \`get_email_attachment(account, message_id, attachment_index, mailbox)\`** returns one attachment as base64-encoded bytes plus filename + content_type. Wire transport is JSON, so binaries are base64; the caller decodes. Same fast-path / cross-mailbox fallback as \`get_email_message\` so a moved-out-of-INBOX message still resolves.

The two tools cooperate: \`get_email_message\` exposes per-attachment indices, \`get_email_attachment\` accepts those indices. No cross-call state required.

## Why

I'm using apple-mail-mcp from a local inbox UI that needs to render an attachment list per email and let the user click to download. Without the metadata array there's nothing to render; without the byte-fetch tool the link has nowhere to point. \`save_email_attachment\` exists but it writes to a server-side path which doesn't help a browser.

## Test plan

- [ ] No-attachment email → \`attachments: []\`.
- [ ] One-attachment email → one entry; \`get_email_attachment(…, 0)\` returns matching bytes.
- [ ] Multi-attachment with inline image → all three entries; inline one has \`is_inline: true\`. Indices fetch the right bytes.
- [ ] \`attachment_index\` out of range → \`{error: \"index_out_of_range\"}\`.
- [ ] Message moved to Archive between calls → still resolves.
- [ ] Permanently deleted → \`{error: \"not_found\"}\`.