### PR TITLE
Fix: support localized inbox mailbox names (FR/DE/ES/IT/PT/NL/JA)

### DIFF
--- a/plugin/apple_mail_mcp/constants.py
+++ b/plugin/apple_mail_mcp/constants.py
@@ -11,11 +11,22 @@ NEWSLETTER_KEYWORD_PATTERNS = [
     "bulletin", "briefing", "news@", "updates@",
 ]
 
-# Folders to skip during broad searches
+# Folders to skip during broad searches.
+# Includes localized variants so non-English Mail.app accounts (Exchange,
+# Outlook, Gmail in non-English locales) skip system folders correctly.
 SKIP_FOLDERS = [
+    # English / IMAP standards
     "Trash", "Junk", "Junk Email", "Deleted Items",
     "Sent", "Sent Items", "Sent Messages", "Drafts",
     "Spam", "Deleted Messages",
+    # French (Exchange/Outlook + Gmail FR)
+    "Corbeille", "Courrier indésirable", "Indésirables",
+    "Éléments supprimés", "Éléments envoyés", "Messages envoyés",
+    "Brouillons", "Boîte d'envoi",
+    # German
+    "Papierkorb", "Gesendet", "Entwürfe", "Werbung",
+    # Spanish
+    "Papelera", "Enviados", "Borradores", "Correo no deseado",
 ]
 
 # Thread subject prefixes to strip when matching threads

--- a/plugin/apple_mail_mcp/core.py
+++ b/plugin/apple_mail_mcp/core.py
@@ -182,16 +182,47 @@ LOWERCASE_HANDLER = """
 """
 
 
+# Localized inbox mailbox names. Mail.app uses the system locale to name
+# the inbox folder for non-IMAP accounts (Exchange, on-my-Mac), so we must
+# try multiple names to find it. IMAP accounts (iCloud, Gmail) typically
+# expose 'INBOX' regardless of system language.
+INBOX_NAMES = [
+    "INBOX",                  # IMAP standard (iCloud, Gmail, Fastmail)
+    "Inbox",                  # English non-IMAP
+    "Boîte de réception",     # French (Exchange/Outlook on FR system)
+    "Boîte aux lettres",      # French alt
+    "Réception",              # French alt
+    "Posteingang",            # German
+    "Bandeja de entrada",     # Spanish
+    "Posta in arrivo",        # Italian
+    "Caixa de entrada",       # Portuguese
+    "Postvak IN",             # Dutch
+    "受信トレイ",             # Japanese
+]
+
+
 def inbox_mailbox_script(
     var_name: str = "inboxMailbox", account_var: str = "anAccount"
 ) -> str:
-    """Return AppleScript snippet to get inbox mailbox with INBOX/Inbox fallback."""
+    """Return AppleScript snippet to resolve the inbox mailbox.
+
+    Iterates through INBOX_NAMES (localized variants) so non-English
+    Mail.app accounts — typically Exchange on a French/German/etc.
+    system where the inbox is 'Boîte de réception' / 'Posteingang' —
+    still resolve correctly.
+    """
+    name_list = ", ".join(f'"{n}"' for n in INBOX_NAMES)
     return f"""
-                try
-                    set {var_name} to mailbox "INBOX" of {account_var}
-                on error
-                    set {var_name} to mailbox "Inbox" of {account_var}
-                end try"""
+                set {var_name} to missing value
+                repeat with __inboxLookupName in {{{name_list}}}
+                    try
+                        set {var_name} to mailbox (__inboxLookupName as string) of {account_var}
+                        exit repeat
+                    end try
+                end repeat
+                if {var_name} is missing value then
+                    error "No inbox mailbox found for account " & (name of {account_var})
+                end if"""
 
 
 def content_preview_script(max_length: int, output_var: str = "outputText") -> str:
@@ -257,6 +288,21 @@ def build_mailbox_ref(
             ref += f'mailbox "{escape_applescript(parts[i])}" of '
         ref += account_var
         return f"set {var_name} to {ref}"
+
+    # When caller asks for "INBOX" (default for most tools), iterate the
+    # localized fallback list so Exchange/non-English inboxes are found.
+    if mailbox.upper() == "INBOX":
+        name_list = ", ".join(f'"{n}"' for n in INBOX_NAMES)
+        return f'''set {var_name} to missing value
+            repeat with __mailboxLookupName in {{{name_list}}}
+                try
+                    set {var_name} to mailbox (__mailboxLookupName as string) of {account_var}
+                    exit repeat
+                end try
+            end repeat
+            if {var_name} is missing value then
+                error "Mailbox not found: {escaped} (no localized inbox match)"
+            end if'''
 
     return f'''try
                 set {var_name} to mailbox "{escaped}" of {account_var}


### PR DESCRIPTION
## Problem

On non-English macOS systems, Mail.app names the inbox folder using the
system locale for non-IMAP accounts (Exchange, on-my-Mac). For example,
on a French Mac, an Exchange/Hotmail/Outlook account exposes its inbox
as `Boîte de réception` rather than `Inbox`.

The current code in `core.py` (`inbox_mailbox_script` and `build_mailbox_ref`)
tries only `INBOX` then `Inbox`, which causes silent failures on these
accounts — every tool that touches the inbox (`get_inbox_overview`,
`list_inbox_emails`, `get_mailbox_unread_counts`, `find_followups`, etc.)
returns "Error accessing inbox" for the affected account while other
accounts on the same Mac work fine.

IMAP accounts (iCloud, Gmail, Fastmail) are unaffected because they
expose `INBOX` regardless of system locale.

## Fix

- Add an `INBOX_NAMES` constant in `core.py` with 11 localized variants
  (FR/EN/DE/ES/IT/PT/NL/JA).
- Replace the binary `try/on error` in `inbox_mailbox_script()` with a
  loop that iterates `INBOX_NAMES`, raising a clear error if none match.
- Apply the same loop in `build_mailbox_ref()` when the caller asks for
  `"INBOX"` (the default for `search_emails`, `move_email`, `manage_trash`,
  `export_emails`, etc.). Custom mailbox names are unchanged.
- Extend `SKIP_FOLDERS` in `constants.py` with French, German, and
  Spanish system folder names so broad searches behave correctly on
  non-English accounts.

## Testing

Tested live on macOS Tahoe 26 with three accounts on the same Mac:

| Account | Type | Inbox name | Total | Unread |
|---|---|---|---|---|
| iCloud | IMAP | `INBOX` | 17 432 | 765 |
| Exchange (Hotmail) | unknown | `Boîte de réception` | 35 087 | 3 044 |
| Google | IMAP | `INBOX` | 10 687 | 182 |

Before the fix, the Exchange account always returned
`Erreur dans Mail : Il est impossible d'obtenir mailbox "INBOX"` /
`mailbox "Inbox"`. After the fix, all three accounts resolve correctly
through every tool I exercised: `get_inbox_overview`,
`get_mailbox_unread_counts`, `list_inbox_emails`, `search_emails`,
`get_top_senders`. No regression on the iCloud / Google accounts.

## Notes

This only changes behavior for callers that previously failed; English
IMAP accounts hit `INBOX` on the first iteration of the loop, so there
is no measurable performance impact.

If you want to extend the locale list further (Russian, Korean, Polish,
etc.), the constant is the single source of truth.
