### PR TITLE
Add synchronize_account tool (push pending IMAP commands)

### DIFF
--- a/plugin/apple_mail_mcp/tools/manage.py
+++ b/plugin/apple_mail_mcp/tools/manage.py
@@ -850,3 +850,99 @@ def create_mailbox(
     return run_applescript(script)
 
 
+
+
+@mcp.tool()
+@inject_preferences
+def synchronize_account(account: Optional[str] = None) -> str:
+    """
+    Force Mail.app to synchronize an account (or every account) with its
+    IMAP / Exchange server right now. Equivalent to clicking the
+    refresh button next to the account or selecting Mailbox → Synchronize.
+
+    Use after `move_email`, `update_email_status`, or `manage_trash`
+    when downstream clients (iPhone, web mail, etc.) need to see the
+    change immediately. Mail.app's natural sync cadence is "automatic"
+    which can be several minutes — this collapses that to one IMAP push.
+
+    Implementation note:
+    --------------------
+    Uses the `synchronize with <account>` AppleScript verb (per Mail.sdef:
+    "Command to trigger synchronizing of an IMAP account with the server")
+    rather than `check for new mail`. The latter is receive-only — it
+    pulls new messages but does NOT push pending IMAP commands like
+    queued moves / archives / flag changes. With `check for new mail`,
+    archives done via `move_email` could sit in Mail.app's local cache
+    for several minutes before reaching the IMAP server, leaving iPhone
+    Mail (which reads IMAP directly) showing already-archived messages
+    still in INBOX. `synchronize with` is the bidirectional verb that
+    drains pending IMAP commands AND fetches new mail.
+
+    Mail.app's synchronize is potentially long-running. We wrap each
+    invocation in `with timeout of N seconds` so the AppleScript returns
+    promptly. When the timeout fires (error -1712) Mail.app keeps the
+    sync running in the background — exactly the fire-and-forget
+    semantics callers expect.
+
+    Args:
+        account: Account name (e.g., "Gmail", "Work"). Omit to sync every
+                 configured account.
+
+    Returns:
+        Confirmation string with the account(s) synced or queued.
+    """
+    # 8 s is comfortably longer than a healthy IMAP sync but short enough
+    # that a stuck account / network blip doesn't block the MCP call. On
+    # timeout we report "queued" — the sync continues asynchronously.
+    PER_ACCOUNT_TIMEOUT_S = 8
+
+    if account is None or not account.strip():
+        script = f'''
+        tell application "Mail"
+            set acctNames to {{}}
+            set queuedNames to {{}}
+            repeat with a in accounts
+                set acctName to name of a
+                set end of acctNames to acctName
+                try
+                    with timeout of {PER_ACCOUNT_TIMEOUT_S} seconds
+                        synchronize with a
+                    end timeout
+                on error errMsg number errNum
+                    if errNum is -1712 then
+                        set end of queuedNames to acctName
+                    end if
+                end try
+            end repeat
+            set AppleScript's text item delimiters to ", "
+            if (count of queuedNames) > 0 then
+                return "Synchronized all accounts: " & (acctNames as string) & " (queued: " & (queuedNames as string) & ")"
+            else
+                return "Synchronized all accounts: " & (acctNames as string)
+            end if
+        end tell
+        '''
+        return run_applescript(script)
+
+    acct_escaped = escape_applescript(account.strip())
+    script = f'''
+    tell application "Mail"
+        try
+            set targetAccount to first account whose name is "{acct_escaped}"
+            try
+                with timeout of {PER_ACCOUNT_TIMEOUT_S} seconds
+                    synchronize with targetAccount
+                end timeout
+                return "Synchronized: {acct_escaped}"
+            on error errMsg number errNum
+                if errNum is -1712 then
+                    return "Synchronizing: {acct_escaped} (queued — push in progress)"
+                end if
+                return "Error: " & errMsg
+            end try
+        on error errMsg
+            return "Error: " & errMsg
+        end try
+    end tell
+    '''
+    return run_applescript(script)


### PR DESCRIPTION
## Summary

Adds a `synchronize_account` tool that forces Mail.app to push pending IMAP changes (queued moves / archives / flag updates) to the server right now, instead of waiting for Mail.app's natural sync cadence (5–30 min on a busy Mac).

## Why

After `move_email`, `update_email_status`, or `manage_trash`, downstream clients reading IMAP directly (iPhone Mail, web mail) keep showing the old state until Mail.app's IMAP push fires on its own schedule. This is a frustrating discrepancy: Mail.app on Mac shows the archive succeeded, iPhone still shows the message in INBOX for many minutes.

I hit this running an email-triage flow on top of `mcp-apple-mail`: every `move_email` to archive looked successful (residual check passes, Mac Mail confirms gone), but my phone kept the message visible for ~15 min until Mail.app's next push.

## Implementation choice — `synchronize with`, not `check for new mail`

Per `Mail.sdef`, the `synchronize` AppleScript verb is documented as **"Command to trigger synchronizing of an IMAP account with the server"** — it's bidirectional, draining the pending IMAP command queue AND fetching new mail. The looks-similar verb `check for new mail` is receive-only: pulls new messages but does NOT push pending moves / flag changes to the server. Using `check for new mail` would silently defeat this tool's purpose.

## Fire-and-forget semantics

`synchronize with` can be long-running on busy / stuck accounts, so each invocation is wrapped in `with timeout of 8 seconds`. On AppleScript timeout (error -1712) we catch it and report the account as "queued" — Mail.app keeps the sync running in the background. Callers trigger the push, they don't need to block until it lands on the server.

For the multi-account path (`account=None`), each account is synchronized in turn under the same per-account timeout, and queued accounts are reported separately in the return string.

## Test plan

- [x] `pytest tests/` — 30 passed, no behavioural change to other tools
- [x] Live test: triggered `move_email` to archive on Gmail account, then `synchronize_account` — iPhone Mail reflected the change within a few seconds (was previously 5–15 min)
- [x] Live test: multi-account variant with 6 accounts — completes promptly, queues any stuck accounts in the return string

Happy to revise based on review.