### PR TITLE
fix: strip CDATA wrappers from email body content

### DIFF
--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -62,6 +62,24 @@ def _resolve_sender_address(account):
     return sender_address or None
 
 
+_CDATA_BLOCK_PATTERN = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
+
+
+def _strip_cdata_wrappers(text):
+    """Remove XML CDATA section markers from user-provided body content.
+
+    LLM callers occasionally wrap email bodies in `<![CDATA[...]]>`. HTML
+    parsers treat the opening `<![CDATA[` as a bogus comment that ends at
+    the first `>` in the actual content, so it's invisible — but the
+    trailing `]]>` has no preceding `<` and renders as literal text at the
+    end of the message. Strip both forms so callers don't have to know.
+    """
+    if not text:
+        return text
+    text = _CDATA_BLOCK_PATTERN.sub(r"\1", text)
+    return text.replace("<![CDATA[", "").replace("]]>", "")
+
+
 def _build_html_from_text(text_body):
     """Return a simple HTML wrapper for plain text content."""
     safe_body = html_escape(text_body or "")
@@ -169,6 +187,9 @@ def create_rich_email_draft(
     """
     if not account or not account.strip():
         return "Error: 'account' is required"
+
+    text_body = _strip_cdata_wrappers(text_body)
+    html_body = _strip_cdata_wrappers(html_body)
 
     recipients_to = _split_addresses(to)
     recipients_cc = _split_addresses(cc)
@@ -497,6 +518,9 @@ def reply_to_email(
         Confirmation message with details of the reply sent, saved draft, or opened draft
     """
 
+    reply_body = _strip_cdata_wrappers(reply_body) or ""
+    body_html = _strip_cdata_wrappers(body_html)
+
     # Escape all user inputs for AppleScript
     safe_account = escape_applescript(account)
     safe_subject_keyword = escape_applescript(subject_keyword)
@@ -806,6 +830,9 @@ def compose_email(
     if mode not in ("send", "draft", "open"):
         return f"Error: Invalid mode '{mode}'. Use: send, draft, open"
 
+    body = _strip_cdata_wrappers(body) or ""
+    body_html = _strip_cdata_wrappers(body_html)
+
     # Validate and resolve attachments early
     attachment_script = ""
     attachment_info = ""
@@ -984,6 +1011,8 @@ def forward_email(
     Returns:
         Confirmation message with details of forwarded email
     """
+
+    message = _strip_cdata_wrappers(message)
 
     # Escape all user inputs for AppleScript
     safe_account = escape_applescript(account)
@@ -1218,6 +1247,8 @@ def manage_drafts(
     Returns:
         Formatted output based on action
     """
+
+    body = _strip_cdata_wrappers(body)
 
     # Escape account for all paths
     safe_account = escape_applescript(account)

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -87,5 +87,71 @@ class ComposeToolTests(unittest.TestCase):
             self.assertIn("Saved in Drafts: yes", result)
 
 
+class StripCdataTests(unittest.TestCase):
+    def test_none_passes_through(self):
+        self.assertIsNone(compose_tools._strip_cdata_wrappers(None))
+
+    def test_empty_passes_through(self):
+        self.assertEqual("", compose_tools._strip_cdata_wrappers(""))
+
+    def test_unwraps_symmetric_block(self):
+        self.assertEqual(
+            "<p>Hello</p>",
+            compose_tools._strip_cdata_wrappers("<![CDATA[<p>Hello</p>]]>"),
+        )
+
+    def test_unwraps_multiline_block(self):
+        self.assertEqual(
+            "\n<p>Hi</p>\n",
+            compose_tools._strip_cdata_wrappers("<![CDATA[\n<p>Hi</p>\n]]>"),
+        )
+
+    def test_strips_stray_closing_marker(self):
+        # This is the symptom users actually see — HTML parsers hide the
+        # opening `<![CDATA[`, but the trailing `]]>` renders as text.
+        self.assertEqual(
+            "<p>Hello</p>",
+            compose_tools._strip_cdata_wrappers("<p>Hello</p>]]>"),
+        )
+
+    def test_strips_stray_opening_marker(self):
+        self.assertEqual(
+            "<p>Hello</p>",
+            compose_tools._strip_cdata_wrappers("<![CDATA[<p>Hello</p>"),
+        )
+
+    def test_leaves_normal_html_untouched(self):
+        html = '<html><body><h1>Weekly Update</h1></body></html>'
+        self.assertEqual(html, compose_tools._strip_cdata_wrappers(html))
+
+
+class CreateRichEmailDraftCdataTests(unittest.TestCase):
+    def test_cdata_wrapped_html_body_is_stripped_in_eml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "cdata.eml"
+
+            with (
+                patch(
+                    "apple_mail_mcp.tools.compose.run_applescript",
+                    return_value="sender@example.com",
+                ),
+                patch("apple_mail_mcp.tools.compose.subprocess.run"),
+            ):
+                compose_tools.create_rich_email_draft(
+                    account="Work",
+                    subject="CDATA Test",
+                    to="team@example.com",
+                    text_body="Plain fallback",
+                    html_body="<![CDATA[<html><body><h1>Hi</h1></body></html>]]>",
+                    output_path=str(output_path),
+                    open_in_mail=False,
+                )
+
+            payload = output_path.read_text()
+            self.assertIn("<h1>Hi</h1>", payload)
+            self.assertNotIn("<![CDATA[", payload)
+            self.assertNotIn("]]>", payload)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- HTML emails composed via this MCP often ended with a stray `]]>` because LLM callers wrap bodies in `<![CDATA[...]]>`. HTML parsers swallow the opening `<![CDATA[` as a bogus comment (it ends at the first `>` in the content), but the trailing `]]>` has no preceding `<` and renders as visible text.
- Added `_strip_cdata_wrappers()` in `plugin/apple_mail_mcp/tools/compose.py` that unwraps symmetric `<![CDATA[...]]>` blocks and strips any stray opening/closing markers.
- Applied at the entry of every compose tool: `create_rich_email_draft`, `reply_to_email`, `compose_email`, `forward_email`, `manage_drafts`.

## Test plan
- [x] Added 8 unit tests for `_strip_cdata_wrappers` covering None, empty, symmetric, multi-line, stray-open, stray-close, and untouched-HTML cases.
- [x] Added integration test verifying CDATA-wrapped `html_body` produces a clean EML in `create_rich_email_draft`.
- [x] Full suite: `PYTHONPATH=plugin pytest tests/` — 34 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)