### PR TITLE
chore: reconcile version strings to 3.1.4 and add drift guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,21 @@ apple-mail-mcp/
 3. Commit and push
 4. Open a Pull Request
 
+## Releasing
+
+Follow these steps when cutting a new release to keep all version strings in sync:
+
+1. Bump `__version__` in `plugin/apple_mail_mcp/__init__.py` to the new version.
+2. Update `apple-mail-mcpb/manifest.json` (`"version"` field) to match.
+3. Update `pyproject.toml` (`version = ...` under `[project]`) to match.
+4. Update both version fields in `server.json` (`"version"` and `"packages"[0]["version"]`) to match.
+5. Run `python3 scripts/check_versions.py` — it must print **OK** before you proceed.
+6. Commit, tag, and push: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+7. Create a GitHub release from the tag.
+8. Build and publish to PyPI: `python -m build && twine upload dist/*` (requires PyPI credentials).
+
+> The test suite also enforces version consistency (`tests/test_version_consistency.py`), so any CI run on a branch with mismatched versions will fail fast.
+
 ## License
 
 MIT -- see [LICENSE](LICENSE).

--- a/plugin/apple_mail_mcp/__init__.py
+++ b/plugin/apple_mail_mcp/__init__.py
@@ -1,5 +1,7 @@
 """Apple Mail MCP - Modular package."""
 
+__version__ = "3.1.4"
+
 from apple_mail_mcp.server import mcp
 
 # UI availability flag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-apple-mail"
-version = "3.1.3"
+version = "3.1.4"
 description = "MCP server giving AI assistants full access to Apple Mail - read, search, compose, organize & analyze emails"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+check_versions.py — Drift guard for version strings.
+
+Reads the version from every file that carries one and asserts they all agree.
+Run from the repo root:
+
+    python scripts/check_versions.py
+
+Exits 0 on success, 1 if any version string disagrees (lists offenders).
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def get_versions(repo_root: Path) -> dict[str, str]:
+    """Return a mapping of {source_label: version_string} for every tracked file."""
+    versions: dict[str, str] = {}
+
+    # 1. apple-mail-mcpb/manifest.json  (single source of truth for the build script)
+    manifest_path = repo_root / "apple-mail-mcpb" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    versions["apple-mail-mcpb/manifest.json"] = manifest["version"]
+
+    # 2. pyproject.toml
+    pyproject_text = (repo_root / "pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject_text, re.MULTILINE)
+    if not match:
+        raise ValueError("Could not find version in pyproject.toml")
+    versions["pyproject.toml"] = match.group(1)
+
+    # 3. server.json — two occurrences: top-level "version" and packages[0]["version"]
+    server = json.loads((repo_root / "server.json").read_text())
+    versions["server.json#version"] = server["version"]
+    versions["server.json#packages[0].version"] = server["packages"][0]["version"]
+
+    # 4. plugin/apple_mail_mcp/__init__.py  __version__
+    init_text = (
+        repo_root / "plugin" / "apple_mail_mcp" / "__init__.py"
+    ).read_text()
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', init_text, re.MULTILINE)
+    if not match:
+        raise ValueError(
+            "Could not find __version__ in plugin/apple_mail_mcp/__init__.py"
+        )
+    versions["plugin/apple_mail_mcp/__init__.py"] = match.group(1)
+
+    return versions
+
+
+def check(repo_root: Path | None = None) -> tuple[bool, dict[str, str]]:
+    """
+    Check that all version strings agree.
+
+    Returns (ok, versions_dict).  ok is True when all strings match.
+    Raises ValueError if a version string cannot be parsed.
+    """
+    if repo_root is None:
+        repo_root = Path(__file__).parent.parent
+    versions = get_versions(repo_root)
+    unique = set(versions.values())
+    return len(unique) == 1, versions
+
+
+def main() -> None:
+    repo_root = Path(__file__).parent.parent
+    try:
+        ok, versions = check(repo_root)
+    except (FileNotFoundError, KeyError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if ok:
+        version = next(iter(versions.values()))
+        print(f"OK — all version strings agree: {version}")
+        for label, ver in versions.items():
+            print(f"  {label}: {ver}")
+        sys.exit(0)
+    else:
+        unique_versions = sorted(set(versions.values()))
+        print(
+            f"FAIL — version strings disagree "
+            f"(found {len(unique_versions)} distinct values: "
+            f"{', '.join(unique_versions)})",
+            file=sys.stderr,
+        )
+        for label, ver in versions.items():
+            marker = "" if len(set(versions.values()) - {ver}) == 0 else "  <-- MISMATCH"
+            print(f"  {label}: {ver}{marker}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/patrickfreyer/apple-mail-mcp",
     "source": "github"
   },
-  "version": "3.1.2",
+  "version": "3.1.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-apple-mail",
-      "version": "3.1.2",
+      "version": "3.1.4",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,49 @@
+"""Tests that all version strings across the repo agree."""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+# Load check_versions from scripts/ without requiring it to be a package
+_REPO_ROOT = Path(__file__).parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "check_versions.py"
+
+spec = importlib.util.spec_from_file_location("check_versions", _SCRIPT)
+_cv = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_cv)  # type: ignore[union-attr]
+
+
+class VersionConsistencyTests(unittest.TestCase):
+    def test_all_version_strings_agree(self):
+        """Every file that carries a version string must declare the same value."""
+        ok, versions = _cv.check(_REPO_ROOT)
+        if not ok:
+            unique = sorted(set(versions.values()))
+            details = "\n".join(f"  {k}: {v}" for k, v in versions.items())
+            self.fail(
+                f"Version strings disagree ({', '.join(unique)}):\n{details}"
+            )
+
+    def test_package_exposes_version(self):
+        """apple_mail_mcp.__version__ must be importable and non-empty."""
+        # Add plugin/ to path so the package is importable (mirrors the pytest invocation)
+        plugin_dir = str(_REPO_ROOT / "plugin")
+        added = False
+        if plugin_dir not in sys.path:
+            sys.path.insert(0, plugin_dir)
+            added = True
+        try:
+            import apple_mail_mcp  # noqa: PLC0415
+
+            ver = getattr(apple_mail_mcp, "__version__", None)
+            self.assertIsNotNone(ver, "apple_mail_mcp.__version__ is not defined")
+            self.assertIsInstance(ver, str, "apple_mail_mcp.__version__ must be a str")
+            self.assertTrue(ver.strip(), "apple_mail_mcp.__version__ must not be empty")
+        finally:
+            if added:
+                sys.path.remove(plugin_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #59

## What changed

| File | Before | After |
|---|---|---|
| `apple-mail-mcpb/manifest.json` | **3.1.4** (already correct) | **3.1.4** (unchanged) |
| `pyproject.toml` | 3.1.3 | **3.1.4** |
| `server.json` (top-level `"version"`) | 3.1.2 | **3.1.4** |
| `server.json` (`"packages"[0]["version"]`) | 3.1.2 | **3.1.4** |
| `plugin/apple_mail_mcp/__init__.py` | _(no `__version__`)_ | **`__version__ = "3.1.4"`** |

## Approach

**Single source of truth:** `plugin/apple_mail_mcp/__init__.py.__version__` is now the package-level constant. `manifest.json` remains the build-script input (unchanged). Both are expected to agree — the drift guard enforces this.

**Drift guard — `scripts/check_versions.py`:** A stdlib-only script that reads the version from all five locations (`manifest.json`, `pyproject.toml`, `server.json` x2, `__init__.py`) and exits non-zero if any disagree, listing the offenders. Run it as part of any release flow:

```
python3 scripts/check_versions.py
```

**Test — `tests/test_version_consistency.py`:** Plain `unittest` (mirrors `test_orphan_watcher.py` style) that calls the same check logic and also verifies `apple_mail_mcp.__version__` is importable and non-empty. All 61 tests pass:

```
PYTHONPATH=plugin python3 -m pytest tests/ -q
# 61 passed in 2.07s
```

**Release checklist:** A new "Releasing" section in `README.md` documents the step-by-step: bump `__version__` -> sync the other files -> run `scripts/check_versions.py` -> tag -> GitHub release -> `python -m build` -> `twine upload`.

## Out of scope (manual follow-ups requiring maintainer credentials)

- **PyPI re-publish** (`mcp-apple-mail` is at 2.2.0 on PyPI; `apple-mail-mcp` is at 0.4.0 — both far behind 3.1.4). Needs Patrick's PyPI token — out of scope for a PR. Tracked in #42.
- **Package name fix** (`mcp-apple-mail` vs `apple-mail-mcp` confusion). Tracked in #57 — should be resolved alongside the next PyPI publish.
- **Broken artifact fix.** Tracked in #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)