### PR TITLE
fix: prevent orphaned osascript from pinning Mail.app's main thread (#58)

### DIFF
--- a/plugin/apple_mail_mcp/core.py
+++ b/plugin/apple_mail_mcp/core.py
@@ -1,9 +1,111 @@
 """Core helpers: AppleScript execution, escaping, parsing, and preference injection."""
 
+import atexit
+import signal
 import subprocess
+import threading
 from typing import Optional, List, Dict, Any, Tuple
 
 from apple_mail_mcp.server import USER_PREFERENCES
+
+
+# ---------------------------------------------------------------------------
+# In-flight osascript child tracking
+# ---------------------------------------------------------------------------
+# All live Popen objects for in-flight osascript calls.  Guarded by
+# _inflight_lock so callers on any thread can safely add/remove entries.
+_inflight_children: set = set()
+_inflight_lock = threading.Lock()
+
+# Sentinel so we only register atexit + signal handlers once.
+_cleanup_registered = False
+_cleanup_lock = threading.Lock()
+
+
+def _kill_inflight_children() -> None:
+    """Kill every in-flight osascript child that is still alive.
+
+    Called from atexit and chained signal handlers so that graceful
+    SIGTERM/SIGHUP/normal-exit paths do not leave orphaned osascript
+    processes behind.  The AppleScript-level ``with timeout`` block (see
+    _apply_applescript_timeout) is the safety net for SIGKILL / os._exit,
+    where these handlers never run.
+    """
+    with _inflight_lock:
+        procs = list(_inflight_children)
+    for proc in procs:
+        try:
+            proc.kill()
+            proc.wait()
+        except Exception:
+            pass
+
+
+def _register_cleanup_once() -> None:
+    """Register atexit and SIGTERM/SIGHUP handlers exactly once, thread-safely.
+
+    Signal handlers may only be set from the main thread; the try/except
+    guards against ImportError or ValueError when called from a worker thread
+    so that module import never crashes in non-main-thread contexts.
+    """
+    global _cleanup_registered
+    with _cleanup_lock:
+        if _cleanup_registered:
+            return
+        _cleanup_registered = True
+
+    atexit.register(_kill_inflight_children)
+
+    # Chain onto any previously installed signal handlers rather than
+    # clobbering them (e.g. FastMCP installs its own SIGTERM handler).
+    for sig in (signal.SIGTERM, signal.SIGHUP):
+        try:
+            old_handler = signal.getsignal(sig)
+
+            def _make_handler(old, signum_capture=sig):
+                def _handler(signum, frame):
+                    _kill_inflight_children()
+                    if callable(old) and old not in (
+                        signal.SIG_DFL,
+                        signal.SIG_IGN,
+                    ):
+                        old(signum, frame)
+                return _handler
+
+            signal.signal(sig, _make_handler(old_handler))
+        except (ValueError, OSError):
+            # Not on the main thread or signal not available — skip silently.
+            pass
+
+
+def _popen_factory(*args, **kwargs) -> subprocess.Popen:
+    """Thin wrapper around subprocess.Popen; injectable for unit tests."""
+    return subprocess.Popen(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# AppleScript timeout injection
+# ---------------------------------------------------------------------------
+
+
+def _apply_applescript_timeout(script: str, timeout: int) -> str:
+    """Wrap *script* in an AppleScript ``with timeout`` block.
+
+    The inner timeout is ``max(timeout - 5, 5)`` seconds, giving the
+    AppleScript interpreter a chance to exit cleanly before the Python-side
+    ``communicate(timeout=…)`` fires.
+
+    Scripts that contain a top-level ``use`` declaration (e.g. ASObjC
+    ``use framework "Foundation"`` in compose.py) cannot legally be nested
+    inside a block, so those are returned unchanged.
+
+    Nested ``with timeout`` blocks are legal in AppleScript, so this wrap is
+    compatible with per-tool timeouts already present in manage.py / search.py.
+    """
+    if any(line.lstrip().startswith("use ") for line in script.splitlines()):
+        return script
+    inner = max(timeout - 5, 5)
+    return f"with timeout of {inner} seconds\n{script}\nend timeout"
 
 
 def inject_preferences(func):
@@ -51,24 +153,56 @@ def _sanitize_for_json(text: str) -> str:
 
 
 def run_applescript(script: str, timeout: int = 120) -> str:
-    """Execute AppleScript via stdin pipe for reliable multi-line handling."""
+    """Execute AppleScript via stdin pipe for reliable multi-line handling.
+
+    Two-layer defence against orphaned osascript children (issue #58):
+
+    1. The script is wrapped in an AppleScript ``with timeout`` block so the
+       interpreter self-terminates even when the parent process is SIGKILLed
+       or exits via os._exit() (e.g. the orphan-watcher in __main__.py).
+
+    2. The live Popen object is tracked in ``_inflight_children``.  An atexit
+       handler and chained SIGTERM/SIGHUP handlers call kill() on any survivors
+       so graceful-exit paths also clean up.
+    """
+    # Ensure signal/atexit handlers are registered (idempotent, main-thread only).
+    _register_cleanup_once()
+
+    # Inject an AppleScript-level timeout so the child self-terminates even if
+    # the Python process is killed before communicate() can enforce its timeout.
+    wrapped = _apply_applescript_timeout(script, timeout)
+
+    proc = _popen_factory(
+        ["osascript", "-"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    with _inflight_lock:
+        _inflight_children.add(proc)
+
     try:
-        result = subprocess.run(
-            ["osascript", "-"],
-            input=script.encode("utf-8"),
-            capture_output=True,
-            timeout=timeout,
+        stdout, stderr = proc.communicate(
+            input=wrapped.encode("utf-8"), timeout=timeout
         )
-        if result.returncode != 0:
-            stderr = result.stderr.decode("utf-8", errors="replace").strip()
-            if stderr:
-                raise Exception(f"AppleScript error: {stderr}")
-        output = result.stdout.decode("utf-8", errors="replace").strip()
-        return _sanitize_for_json(output)
     except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
         raise Exception("AppleScript execution timed out")
     except Exception as e:
         raise Exception(f"AppleScript execution failed: {str(e)}")
+    finally:
+        with _inflight_lock:
+            _inflight_children.discard(proc)
+
+    if proc.returncode != 0:
+        stderr_text = stderr.decode("utf-8", errors="replace").strip()
+        if stderr_text:
+            raise Exception(f"AppleScript error: {stderr_text}")
+
+    output = stdout.decode("utf-8", errors="replace").strip()
+    return _sanitize_for_json(output)
 
 
 def normalize_search_terms(

--- a/tests/test_core_applescript.py
+++ b/tests/test_core_applescript.py
@@ -1,0 +1,244 @@
+"""Tests for AppleScript timeout injection and in-flight child tracking in core.py.
+
+Uses dependency injection (Popen factory + module-level registry) rather than
+calling real osascript, so these tests run in CI on Linux with no Mail.app.
+"""
+
+import subprocess
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# _apply_applescript_timeout
+# ---------------------------------------------------------------------------
+
+
+class TestApplyApplescriptTimeout(unittest.TestCase):
+    """Tests for the _apply_applescript_timeout helper."""
+
+    def setUp(self):
+        # Import here so module-level side-effects (signal handlers) run inside
+        # the test process only once and predictably.
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        self._fn = _apply_applescript_timeout
+
+    def test_wraps_normal_script(self):
+        """Normal script is wrapped in 'with timeout of <inner> seconds'."""
+        script = 'tell application "Mail"\n    get subject of first message\nend tell'
+        result = self._fn(script, timeout=120)
+        self.assertTrue(
+            result.startswith("with timeout of "),
+            msg=f"Expected 'with timeout of ...' at start; got:\n{result}",
+        )
+        self.assertIn("end timeout", result)
+        self.assertIn(script, result)
+
+    def test_inner_is_timeout_minus_five(self):
+        """Inner timeout value is max(timeout-5, 5)."""
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        script = 'display dialog "hello"'
+        result = _apply_applescript_timeout(script, timeout=120)
+        # inner should be 115
+        self.assertIn("with timeout of 115 seconds", result)
+
+    def test_inner_floor_is_five(self):
+        """Inner timeout is floored at 5 even when Python timeout is very small."""
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        script = 'display dialog "hello"'
+        # timeout=7 -> inner = max(2, 5) = 5
+        result = _apply_applescript_timeout(script, timeout=7)
+        self.assertIn("with timeout of 5 seconds", result)
+
+    def test_leaves_use_script_unchanged(self):
+        """Scripts with a top-level 'use' declaration are returned as-is."""
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        script = (
+            "use framework \"Foundation\"\n"
+            "use scripting additions\n"
+            'set x to current application\n'
+        )
+        result = _apply_applescript_timeout(script, timeout=120)
+        self.assertEqual(result, script)
+
+    def test_indented_use_line_also_skipped(self):
+        """A 'use' line with leading whitespace is also detected and skipped."""
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        script = '    use framework "AppKit"\nset x to 1'
+        result = _apply_applescript_timeout(script, timeout=120)
+        self.assertEqual(result, script)
+
+    def test_use_inside_handler_not_mistaken(self):
+        """A word 'use' that is NOT a line-leading directive is wrapped normally."""
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        # 'use' appears inside a string, not as the first token of any line
+        script = 'set x to "I use Mail a lot"\ntell application "Mail"\nend tell'
+        result = _apply_applescript_timeout(script, timeout=120)
+        self.assertIn("with timeout of", result)
+        self.assertIn("end timeout", result)
+
+
+# ---------------------------------------------------------------------------
+# In-flight children registry
+# ---------------------------------------------------------------------------
+
+
+class FakePopen:
+    """Minimal fake that mimics subprocess.Popen for registry tests."""
+
+    def __init__(self, returncode=0, stdout=b"", stderr=b"", delay=0.0):
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._delay = delay
+        self.killed = False
+        self.stdin = MagicMock()
+        self.stdin.write = MagicMock()
+        self.stdin.close = MagicMock()
+
+    def communicate(self, input=None, timeout=None):
+        if self._delay:
+            time.sleep(self._delay)
+        return (self._stdout, self._stderr)
+
+    def kill(self):
+        self.killed = True
+
+    def wait(self):
+        pass
+
+
+class TestInflightRegistry(unittest.TestCase):
+    """Tests for in-flight Popen tracking inside run_applescript."""
+
+    def _run_with_fake_popen(self, fake_proc, timeout=120):
+        """
+        Invoke run_applescript with a factory that always returns *fake_proc*.
+
+        We patch core._popen_factory which run_applescript should call instead
+        of subprocess.Popen directly.
+        """
+        from apple_mail_mcp import core
+        with patch.object(core, "_popen_factory", return_value=fake_proc):
+            return core.run_applescript("display dialog \"hi\"", timeout=timeout)
+
+    def test_child_registered_while_running(self):
+        """Popen is in _inflight_children while communicate() is blocked."""
+        from apple_mail_mcp import core
+
+        barrier = threading.Event()
+        observed_in_registry = []
+
+        class BlockingPopen(FakePopen):
+            def communicate(self, input=None, timeout=None):
+                # Signal the test thread that we are inside communicate()
+                barrier.set()
+                # Block until the test has snapshotted the registry
+                time.sleep(0.15)
+                return (b"ok", b"")
+
+        proc = BlockingPopen()
+
+        def _run():
+            self._run_with_fake_popen(proc)
+
+        t = threading.Thread(target=_run)
+        t.start()
+
+        # Wait until communicate() is entered
+        barrier.wait(timeout=2.0)
+
+        with core._inflight_lock:
+            observed_in_registry.append(proc in core._inflight_children)
+
+        t.join(timeout=2.0)
+
+        self.assertTrue(
+            observed_in_registry[0],
+            "Popen should be in _inflight_children while communicate() is running",
+        )
+
+    def test_child_deregistered_after_success(self):
+        """Popen is removed from _inflight_children after a successful call."""
+        from apple_mail_mcp import core
+
+        proc = FakePopen(stdout=b"hello", stderr=b"")
+        self._run_with_fake_popen(proc)
+
+        with core._inflight_lock:
+            self.assertNotIn(
+                proc,
+                core._inflight_children,
+                "Popen should be removed from _inflight_children after completion",
+            )
+
+    def test_child_deregistered_after_timeout(self):
+        """Popen is removed and killed after TimeoutExpired."""
+        from apple_mail_mcp import core
+
+        class TimeoutPopen(FakePopen):
+            def communicate(self, input=None, timeout=None):
+                raise subprocess.TimeoutExpired(cmd="osascript", timeout=timeout)
+
+        proc = TimeoutPopen()
+        with patch.object(core, "_popen_factory", return_value=proc):
+            with self.assertRaises(Exception, msg="Should raise on timeout"):
+                core.run_applescript("display dialog \"x\"", timeout=1)
+
+        with core._inflight_lock:
+            self.assertNotIn(proc, core._inflight_children)
+        self.assertTrue(proc.killed, "kill() should have been called on timeout")
+
+    def test_child_deregistered_after_error(self):
+        """Popen is removed from registry even if communicate() raises unexpectedly."""
+        from apple_mail_mcp import core
+
+        class BrokenPopen(FakePopen):
+            def communicate(self, input=None, timeout=None):
+                raise OSError("pipe broken")
+
+        proc = BrokenPopen()
+        with patch.object(core, "_popen_factory", return_value=proc):
+            with self.assertRaises(Exception):
+                core.run_applescript("display dialog \"x\"", timeout=120)
+
+        with core._inflight_lock:
+            self.assertNotIn(proc, core._inflight_children)
+
+    def test_return_value_preserved(self):
+        """run_applescript returns the stdout content (sanitized) unchanged."""
+        from apple_mail_mcp import core
+
+        proc = FakePopen(stdout=b"hello world\r\n", stderr=b"")
+        result = self._run_with_fake_popen(proc)
+        self.assertEqual(result, "hello world")
+
+    def test_error_on_nonzero_returncode(self):
+        """run_applescript raises when osascript exits non-zero with stderr."""
+        from apple_mail_mcp import core
+
+        class FailPopen(FakePopen):
+            def __init__(self):
+                super().__init__(returncode=1, stderr=b"some error")
+
+            @property
+            def returncode(self):
+                return 1
+
+            @returncode.setter
+            def returncode(self, v):
+                pass
+
+            def communicate(self, input=None, timeout=None):
+                return (b"", b"some error")
+
+        proc = FailPopen()
+        with patch.object(core, "_popen_factory", return_value=proc):
+            with self.assertRaises(Exception, msg="Should raise on AppleScript error"):
+                core.run_applescript("bad script", timeout=120)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #58

## Root cause

`run_applescript()` used `subprocess.run(["osascript", "-"], timeout=120)`. The Python-side timeout only fires if the MCP server stays alive. When the MCP server is killed mid-call (the normal case when a Claude session ends, AND the existing `_start_orphan_watcher` in `__main__.py` calls `os._exit(0)` on parent reparent), the osascript child is orphaned, reparents to launchd, and — because the generated AppleScript has no `with timeout` block — waits on its pending Apple Event reply forever. Mail.app services AppleScript on its main thread, so a single bulk-read orphan pins Mail's UI at ~95% CPU indefinitely.

## Two-layer fix

**Layer 1 — AppleScript-level `with timeout` (the SIGKILL / `os._exit` safety net):**

A new helper `_apply_applescript_timeout()` wraps every outgoing script in:

```applescript
with timeout of <timeout-5> seconds
  <original script>
end timeout
```

This means osascript self-terminates even when the Python process is killed before `communicate()` can enforce its timeout. Scripts containing a top-level `use` declaration (ASObjC scripts in compose.py) are returned unchanged because `use` cannot legally sit inside a block. Nested `with timeout` blocks are legal in AppleScript and are fully compatible with per-tool timeouts already in manage.py / search.py.

**Layer 2 — in-flight child tracking + signal/atexit cleanup (graceful-exit paths):**

`run_applescript()` switches from `subprocess.run()` to `Popen` + `communicate(timeout=…)`. The live `Popen` object is tracked in a lock-guarded module-level `_inflight_children` set — added on spawn, removed in a `finally` block. `_register_cleanup_once()` wires up an `atexit` handler and chained `SIGTERM`/`SIGHUP` handlers (registered from the main thread only; guarded against worker-thread import) that call `kill()` + `wait()` on any survivors. On `TimeoutExpired`, the child is killed and reaped immediately. All existing return/error semantics are preserved exactly.

## Tests

12 new unit tests in `tests/test_core_applescript.py` (plain `unittest`, dependency-injectable `_popen_factory`, no actual osascript calls — runs in CI on Linux with no Mail.app):

- `_apply_applescript_timeout`: wrapping, inner-value arithmetic (`max(timeout-5, 5)`), floor at 5, `use`-script pass-through, indented-`use` detection, false-positive guard
- `_inflight_children` registry: register-on-spawn, deregister-on-success, deregister-on-timeout (with `kill()`), deregister-on-error, return-value preservation, error on non-zero returncode

Full suite: **71 passed** (59 existing + 12 new).

## Future work

The optional enhancement from the bug report — chunking bulk content reads into batches of message IDs rather than one `get content of every message` Apple Event — would further reduce the blast radius of any single stalled call and would also address the performance concerns in #41. That is a larger, independently reviewable change and is not included here.

## Credit

Reported by Adrian Giles (adrian@fortress.games).

🤖 Generated with [Claude Code](https://claude.com/claude-code)