### PR TITLE
fix: poll for Mail focus before pasting to prevent silent empty sends

### DIFF
--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -461,7 +461,17 @@ delay 2.5
 -- The Cmd+A here selects the entire body (which is why we can't have the
 -- attachment placed yet — it would be selected and replaced by the paste).
 tell application "System Events"
-    set frontmost of process "Mail" to true
+    -- Poll until Mail is genuinely frontmost before driving the keyboard.
+    -- A single `set frontmost` + fixed delay can fire the tab/paste keystrokes
+    -- before the compose window has focus, producing a silent empty send.
+    set focusWaited to 0
+    repeat until (frontmost of process "Mail") or (focusWaited is greater than or equal to 40)
+        try
+            set frontmost of process "Mail" to true
+        end try
+        delay 0.1
+        set focusWaited to focusWaited + 1
+    end repeat
     delay 0.5
     tell process "Mail"
         -- Tab through: To -> Cc -> Bcc -> Subject -> Body
@@ -827,12 +837,34 @@ tell application "Mail"
                 {attachment_script}
             end tell
 
-            -- Paste reply body (HTML already on clipboard from Step 1)
+            -- Paste reply body (HTML already on clipboard from Step 1).
+            -- The body is inserted via a blind Cmd+V into the compose window, so the
+            -- window MUST have keyboard focus when the keystroke fires. If Mail is not
+            -- frontmost at that moment (common on the first compose of a session, when
+            -- another app holds focus, or when the machine is busy), the paste lands
+            -- nowhere and an EMPTY reply is sent with no error returned.
+            --
+            -- We deliberately do NOT verify the paste by reading `content of
+            -- replyMessage` afterwards: Mail's GUI editor buffer is decoupled from the
+            -- scriptable `content` property, so reading it always returns the pre-paste
+            -- value (verified empirically — it reports 0 chars even after a successful
+            -- paste). A content-read-back guard would therefore false-fail every send.
+            -- Instead we make the paste deterministic by polling until Mail is genuinely
+            -- frontmost (re-asserting focus each iteration) before issuing the keystroke.
             set visible of replyMessage to true
             activate
-            delay 1.5
 
             tell application "System Events"
+                set focusWaited to 0
+                repeat until (frontmost of process "Mail") or (focusWaited is greater than or equal to 40)
+                    try
+                        set frontmost of process "Mail" to true
+                    end try
+                    delay 0.1
+                    set focusWaited to focusWaited + 1
+                end repeat
+                -- settle delay so the compose window's body holds keyboard focus
+                delay 0.8
                 tell process "Mail"
                     keystroke "v" using command down
                 end tell

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -641,5 +641,102 @@ class ManageDraftsCreateSenderOverrideTests(unittest.TestCase):
         self.assertTrue(result.startswith("Error: 'from_address'"))
 
 
+class PasteFocusHardeningTests(unittest.TestCase):
+    """Regression guard for the silent empty-send bug.
+
+    The HTML body is inserted via a blind Cmd+V into the compose window, which
+    only lands if Mail is frontmost when the keystroke fires. The original code
+    relied on a single `activate` + fixed `delay`, which intermittently sent an
+    empty message when the window had not yet gained focus. The fix polls until
+    Mail is genuinely frontmost before pasting. These tests assert the poll is
+    present in the generated AppleScript and runs BEFORE the paste keystroke.
+
+    They also lock in the deliberate decision NOT to verify via
+    `content of <message>`: Mail's GUI editor buffer is decoupled from the
+    scriptable `content` property, so a content-read-back guard would
+    false-fail every send.
+    """
+
+    FOCUS_POLL = (
+        'repeat until (frontmost of process "Mail") '
+        "or (focusWaited is greater than or equal to 40)"
+    )
+    PASTE = 'keystroke "v" using command down'
+
+    def _render_reply(self, **overrides):
+        kwargs = dict(
+            account="Work",
+            subject_keyword="test",
+            reply_body="Reply body text",
+            body_html="<p>Reply body text</p>",
+            send=True,
+        )
+        kwargs.update(overrides)
+        with (
+            patch(
+                "apple_mail_mcp.tools.compose.subprocess.run",
+                return_value=_make_subprocess_result(),
+            ) as mock_run,
+            patch(
+                "apple_mail_mcp.tools.compose.run_applescript",
+                return_value="a@b.com",
+            ),
+        ):
+            compose_tools.reply_to_email(**kwargs)
+        return mock_run.call_args.kwargs["input"].decode("utf-8")
+
+    def _render_compose_html(self):
+        with (
+            patch(
+                "apple_mail_mcp.tools.compose.subprocess.run",
+                return_value=_make_subprocess_result(),
+            ) as mock_run,
+            patch(
+                "apple_mail_mcp.tools.compose.run_applescript",
+                return_value="a@b.com",
+            ),
+        ):
+            compose_tools.compose_email(
+                account="Work",
+                to="x@example.com",
+                subject="s",
+                body="Body text",
+                body_html="<p>Body text</p>",
+                mode="send",
+            )
+        return mock_run.call_args.kwargs["input"].decode("utf-8")
+
+    def test_reply_polls_for_focus_before_pasting(self):
+        script = self._render_reply()
+        self.assertIn(self.FOCUS_POLL, script)
+        self.assertLess(
+            script.index(self.FOCUS_POLL),
+            script.index(self.PASTE),
+            "focus poll must run before the paste keystroke",
+        )
+
+    def test_reply_drops_fragile_fixed_predelay(self):
+        # The fragile original inserted a single `delay 1.5` between `activate`
+        # and the paste, with no frontmost re-assertion. The fix replaces that
+        # fixed gamble with a focus poll, so the 1.5s pre-paste delay is gone.
+        script = self._render_reply()
+        self.assertNotIn("delay 1.5", script)
+
+    def test_reply_does_not_read_back_content_as_guard(self):
+        # Mail's `content` property does not reflect a GUI paste, so any
+        # `content of replyMessage` verification would false-fail every send.
+        script = self._render_reply()
+        self.assertNotIn("content of replyMessage", script)
+
+    def test_compose_html_polls_for_focus_before_pasting(self):
+        script = self._render_compose_html()
+        self.assertIn(self.FOCUS_POLL, script)
+        self.assertLess(
+            script.index(self.FOCUS_POLL),
+            script.index(self.PASTE),
+            "focus poll must run before the paste keystroke",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`reply_to_email` and `compose_email` (HTML path) insert the body via a **blind `Cmd+V`** into the Mail compose window. That paste only lands if Mail is frontmost when the keystroke fires. The previous code relied on a single `activate` + fixed `delay 1.5` (reply) / `set frontmost` + `delay 0.5` (new message).

On a cold start (first compose of a session, another app holding focus, or a busy machine), the keystroke fired **before the compose window had keyboard focus** → the paste landed nowhere → a fully-sent email containing **only the signature**. The tool still returned `"Reply sent successfully!"` because it confirms the AppleScript *completed*, not that the body was *populated*.

This was hit in production: a reply went out empty, and an identical retry (Mail now warm) succeeded — the signature of an intermittent focus race.

## Fix

Poll until `frontmost of process "Mail"` is true (re-asserting focus each iteration, up to ~4s), then a short settle delay, **before** issuing the paste keystroke. Applied to **both** the reply and new-message HTML paths.

### Why not verify the body before sending?
A content-read-back guard (`content of replyMessage`) was the obvious idea but is **actively dangerous here**: Mail's GUI editor buffer is decoupled from the scriptable `content` property — verified empirically, it reads **0 chars even after a successful paste**. Such a guard would false-fail *every* send. Documented in code comments so it isn't reintroduced.

## Tests
- New `PasteFocusHardeningTests` (4 tests): focus poll present and ordered **before** the paste keystroke in both paths; fragile fixed `delay 1.5` removed; no `content of replyMessage` read-back reintroduced.
- **40/40** tests pass.
- All four generated script variants (reply send/draft/open + new HTML message) pass `osacompile`.
- **Live draft-mode round-trip** against real Mail.app confirmed the body lands (unique marker found in the saved draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)