### PR TITLE
fix: skip with-timeout wrap for scripts defining AppleScript handlers (#63)

### DIFF
--- a/apple-mail-mcpb/manifest.json
+++ b/apple-mail-mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "Apple Mail MCP",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Natural language interface for Apple Mail with 27 tools — email search, composition, bulk operations, smart inbox analytics, folder management, and security-hardened destructive operations. Includes Email Management Expert Skill and Interactive UI Dashboard.",
   "author": {
     "name": "Patrick Freyer"

--- a/plugin/apple_mail_mcp/core.py
+++ b/plugin/apple_mail_mcp/core.py
@@ -1,6 +1,7 @@
 """Core helpers: AppleScript execution, escaping, parsing, and preference injection."""
 
 import atexit
+import re
 import signal
 import subprocess
 import threading
@@ -88,6 +89,12 @@ def _popen_factory(*args, **kwargs) -> subprocess.Popen:
 # ---------------------------------------------------------------------------
 
 
+# Handler definitions ("on name(...)" / "to name(...)") are only legal at the
+# top level of an AppleScript — never inside a block.  "on error" is a try
+# clause, not a handler definition, so it must not trigger the guard.
+_HANDLER_DEFINITION_RE = re.compile(r"^\s*(?:on|to)\s+(?!error\b)\w+", re.MULTILINE)
+
+
 def _apply_applescript_timeout(script: str, timeout: int) -> str:
     """Wrap *script* in an AppleScript ``with timeout`` block.
 
@@ -95,14 +102,23 @@ def _apply_applescript_timeout(script: str, timeout: int) -> str:
     AppleScript interpreter a chance to exit cleanly before the Python-side
     ``communicate(timeout=…)`` fires.
 
-    Scripts that contain a top-level ``use`` declaration (e.g. ASObjC
-    ``use framework "Foundation"`` in compose.py) cannot legally be nested
-    inside a block, so those are returned unchanged.
+    Two classes of script cannot legally be nested inside a block and are
+    returned unchanged:
+
+    * scripts with a top-level ``use`` declaration (e.g. ASObjC
+      ``use framework "Foundation"`` in compose.py);
+    * scripts that define handlers (``on name(...)`` / ``to name(...)``) —
+      handler definitions are only legal at the top level, so wrapping them
+      fails with 'Expected "end" but found "on"' (-2741, issue #63).  These
+      scripts keep their own inner ``with timeout`` blocks, and the
+      Python-side ``communicate(timeout=…)`` kill still covers them.
 
     Nested ``with timeout`` blocks are legal in AppleScript, so this wrap is
     compatible with per-tool timeouts already present in manage.py / search.py.
     """
     if any(line.lstrip().startswith("use ") for line in script.splitlines()):
+        return script
+    if _HANDLER_DEFINITION_RE.search(script):
         return script
     inner = max(timeout - 5, 5)
     return f"with timeout of {inner} seconds\n{script}\nend timeout"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-apple-mail"
-version = "3.1.5"
+version = "3.1.6"
 description = "MCP server giving AI assistants full access to Apple Mail - read, search, compose, organize & analyze emails"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/patrickfreyer/apple-mail-mcp",
     "source": "github"
   },
-  "version": "3.1.5",
+  "version": "3.1.6",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-apple-mail",
-      "version": "3.1.5",
+      "version": "3.1.6",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_core_applescript.py
+++ b/tests/test_core_applescript.py
@@ -79,6 +79,67 @@ class TestApplyApplescriptTimeout(unittest.TestCase):
         self.assertIn("with timeout of", result)
         self.assertIn("end timeout", result)
 
+    def test_leaves_handler_script_unchanged(self):
+        """Scripts defining an 'on name(...)' handler are returned as-is.
+
+        Handler definitions are only legal at the top level of an AppleScript;
+        wrapping them in 'with timeout' raises
+        'Expected "end" but found "on" (-2741)' (issue #63).
+        """
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        script = (
+            "on sanitize_field(value)\n"
+            "    return value\n"
+            "end sanitize_field\n"
+            'tell application "Mail"\n'
+            "    get subject of first message\n"
+            "end tell"
+        )
+        result = _apply_applescript_timeout(script, timeout=120)
+        self.assertEqual(result, script)
+
+    def test_indented_handler_also_skipped(self):
+        """Handler definitions with leading whitespace are also detected."""
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        script = (
+            "    on stripPrefixes(subj)\n"
+            "        return subj\n"
+            "    end stripPrefixes\n"
+            "set x to 1"
+        )
+        result = _apply_applescript_timeout(script, timeout=120)
+        self.assertEqual(result, script)
+
+    def test_to_handler_also_skipped(self):
+        """The 'to name(...)' handler form is also detected and skipped."""
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        script = "to greet(x)\n    return x\nend greet\ngreet(\"hi\")"
+        result = _apply_applescript_timeout(script, timeout=120)
+        self.assertEqual(result, script)
+
+    def test_on_error_clause_still_wrapped(self):
+        """'on error' clauses inside try blocks are NOT handler definitions."""
+        from apple_mail_mcp.core import _apply_applescript_timeout
+        script = (
+            'tell application "Mail"\n'
+            "    try\n"
+            "        get subject of first message\n"
+            "    on error errMsg\n"
+            '        return "failed"\n'
+            "    end try\n"
+            "end tell"
+        )
+        result = _apply_applescript_timeout(script, timeout=120)
+        self.assertIn("with timeout of", result)
+        self.assertIn("end timeout", result)
+
+    def test_lowercase_handler_template_skipped(self):
+        """A script embedding the shared LOWERCASE_HANDLER template is skipped."""
+        from apple_mail_mcp.core import _apply_applescript_timeout, LOWERCASE_HANDLER
+        script = LOWERCASE_HANDLER + '\ntell application "Mail"\nend tell'
+        result = _apply_applescript_timeout(script, timeout=120)
+        self.assertEqual(result, script)
+
 
 # ---------------------------------------------------------------------------
 # In-flight children registry


### PR DESCRIPTION
Fixes #63.

## Problem

The central `with timeout` wrap from #61 nested AppleScript handler definitions (`on name(...)`) inside a block. Handler definitions are only legal at the top level of a script, so every handler-bearing tool died instantly:

```
AppleScript error: 39:41: syntax error: Expected "end" but found "on". (-2741)
```

Broken tools on v3.1.5: `search_emails` (3 handlers + `LOWERCASE_HANDLER` for body search) and the smart inbox tools (`get_awaiting_reply`, `get_needs_response`, `get_top_senders` via `stripPrefixes` / `LOWERCASE_HANDLER`).

Reported by Adrian Giles (fortress.games), the same external user behind #58 — his root-cause analysis was again exactly right. Confirmed live before fixing: `search_emails` failed with the above error on every invocation.

## Fix

One guard in `_apply_applescript_timeout`: return the script unchanged when it defines a handler (`on`/`to` + identifier, with `on error` clauses excluded from detection — they are try clauses, not handler definitions). Handler-bearing scripts keep their own inner `with timeout` blocks, and the Python-side `communicate(timeout=...)` kill + in-flight child tracking from #61 still cover them, so the orphaned-osascript protection from #58/#61 remains intact for those tools.

Also bumps 3.1.5 → 3.1.6 across all manifests (drift guard green) since 3.1.5 is already tagged.

## Verification

- Minimal repro confirmed at the osascript level: handler inside `with timeout` → -2741; handler at top level → works
- TDD: 5 new tests added and watched fail before the fix; full suite 82/82 green after
- Live end-to-end on this machine with the patched code: `search_emails(sender='adrian@fortress.games')` returns results; `get_top_senders` works; non-handler scripts still get wrapped and execute
- `scripts/check_versions.py` green at 3.1.6

## Note

PyPI publish of the pending release should wait for this (per Adrian's report) — 3.1.5 ships broken search/smart-inbox tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)