### PR TITLE
feat: full flag color support (set, report, query)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ claude mcp add apple-mail -- /bin/bash $(pwd)/start_mcp.sh
 | `list_inbox_emails` | List emails with account/read-status filtering and optional content preview |
 | `get_mailbox_unread_counts` | Unread counts per mailbox or per-account summary |
 | `list_accounts` | List all configured Mail accounts |
-| `search_emails` | Unified search — subject, sender, body text, dates, attachments, cross-account |
+| `search_emails` | Unified search — subject, sender, body text, dates, attachments, flag status/color, cross-account |
 | `get_email_thread` | Conversation thread view |
 
 ### Organization

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ claude mcp add apple-mail -- /bin/bash $(pwd)/start_mcp.sh
 | `list_mailboxes` | Folder hierarchy with message counts |
 | `create_mailbox` | Create new mailboxes (supports nested paths) |
 | `move_email` | Move/archive emails with filters (subject, sender, date, read status, dry-run) |
-| `update_email_status` | Mark read/unread, flag/unflag — by filters or message IDs |
+| `update_email_status` | Mark read/unread, flag/unflag (optional flag color) — by filters or message IDs |
 | `manage_trash` | Soft delete, permanent delete, empty trash (with dry-run) |
 
 ### Composition

--- a/apple-mail-mcpb/manifest.json
+++ b/apple-mail-mcpb/manifest.json
@@ -90,7 +90,7 @@
     },
     {
       "name": "update_email_status",
-      "description": "Update email status in batch — mark as read/unread, flag/unflag. Requires at least one filter or explicit apply_to_all for safety."
+      "description": "Update email status in batch — mark as read/unread, flag/unflag with optional flag color. Requires at least one filter or explicit apply_to_all for safety."
     },
     {
       "name": "manage_trash",

--- a/apple-mail-mcpb/manifest.json
+++ b/apple-mail-mcpb/manifest.json
@@ -86,7 +86,7 @@
     },
     {
       "name": "search_emails",
-      "description": "Unified email search with 16 filter parameters: account, mailbox, subject, body, sender, date range, read status, attachments, flagged, newsletter detection, thread view. Supports cross-account search, JSON output, and uses fast native Mail.app filtering."
+      "description": "Unified email search with filter parameters: account, mailbox, subject, body, sender, date range, read status, attachments, flagged (with optional flag color), newsletter detection, thread view. Supports cross-account search, JSON output, and uses fast native Mail.app filtering."
     },
     {
       "name": "update_email_status",

--- a/apple-mail-mcpb/manifest.json
+++ b/apple-mail-mcpb/manifest.json
@@ -86,7 +86,7 @@
     },
     {
       "name": "search_emails",
-      "description": "Unified email search with filter parameters: account, mailbox, subject, body, sender, date range, read status, attachments, flagged (with optional flag color), newsletter detection, thread view. Supports cross-account search, JSON output, and uses fast native Mail.app filtering."
+      "description": "Unified email search with filter parameters: account, mailbox, subject, body text (slower, per-message), sender, date range, read status, attachments, flagged (with optional flag color). Supports cross-account search, JSON output, and uses fast native Mail.app filtering. For thread view use get_email_thread; for newsletter detection use the smart inbox tools."
     },
     {
       "name": "update_email_status",

--- a/plugin/apple_mail_mcp/constants.py
+++ b/plugin/apple_mail_mcp/constants.py
@@ -43,6 +43,12 @@ FLAG_COLORS = {
     "grey": 6,
 }
 
+# Reverse mapping: flag index -> canonical color name (the "grey" alias is
+# accepted on input only; index 6 always reports as "gray").
+FLAG_COLOR_NAMES = {
+    index: name for name, index in FLAG_COLORS.items() if name != "grey"
+}
+
 # Thread subject prefixes to strip when matching threads
 THREAD_PREFIXES = ["Re:", "Fwd:", "FW:", "RE:", "Fw:"]
 

--- a/plugin/apple_mail_mcp/constants.py
+++ b/plugin/apple_mail_mcp/constants.py
@@ -29,6 +29,20 @@ SKIP_FOLDERS = [
     "Papelera", "Enviados", "Borradores", "Correo no deseado",
 ]
 
+# Apple Mail flag colors -> AppleScript `flag index` values.
+# Mail only scripts the seven indexed colors; custom flag names assigned in
+# the UI are not accessible via AppleScript. An index of -1 means unflagged.
+FLAG_COLORS = {
+    "red": 0,
+    "orange": 1,
+    "yellow": 2,
+    "green": 3,
+    "blue": 4,
+    "purple": 5,
+    "gray": 6,
+    "grey": 6,
+}
+
 # Thread subject prefixes to strip when matching threads
 THREAD_PREFIXES = ["Re:", "Fwd:", "FW:", "RE:", "Fw:"]
 

--- a/plugin/apple_mail_mcp/core.py
+++ b/plugin/apple_mail_mcp/core.py
@@ -414,6 +414,31 @@ def skip_folders_condition(var_name: str = "mailboxName") -> str:
     return f"{var_name} is not in {{{folder_list}}}"
 
 
+def resolve_flag_color(flag_color: str) -> int:
+    """Map a flag color name to Mail's `flag index` value (0-6).
+
+    Raises ValueError for colors outside Mail's seven indexed flags.
+    """
+    from apple_mail_mcp.constants import FLAG_COLORS
+
+    flag_index = FLAG_COLORS.get(flag_color.strip().lower())
+    if flag_index is None:
+        valid = ", ".join(c for c in FLAG_COLORS if c != "grey")
+        raise ValueError(f"Invalid flag_color '{flag_color}'. Use: {valid}")
+    return flag_index
+
+
+def read_flag_index_script(var_name: str = "messageFlagIndex") -> str:
+    """Return AppleScript snippet reading a message's flag index into var_name.
+
+    The variable defaults to -1 (unflagged) when the property is unreadable.
+    """
+    return f"""set {var_name} to -1
+                                                try
+                                                    set {var_name} to flag index of aMessage
+                                                end try"""
+
+
 def build_mailbox_ref(
     mailbox: str,
     account_var: str = "targetAccount",

--- a/plugin/apple_mail_mcp/core.py
+++ b/plugin/apple_mail_mcp/core.py
@@ -432,10 +432,15 @@ def read_flag_index_script(var_name: str = "messageFlagIndex") -> str:
     """Return AppleScript snippet reading a message's flag index into var_name.
 
     The variable defaults to -1 (unflagged) when the property is unreadable.
+    `flag index` and `flagged status` are independent properties in Mail —
+    unflagging only clears the boolean, leaving a residual index — so the
+    read is gated on `flagged status` to treat such messages as unflagged.
     """
     return f"""set {var_name} to -1
                                                 try
-                                                    set {var_name} to flag index of aMessage
+                                                    if flagged status of aMessage then
+                                                        set {var_name} to flag index of aMessage
+                                                    end if
                                                 end try"""
 
 

--- a/plugin/apple_mail_mcp/tools/manage.py
+++ b/plugin/apple_mail_mcp/tools/manage.py
@@ -332,9 +332,10 @@ def update_email_status(
     if flag_color is not None:
         if action != "flag":
             return "Error: 'flag_color' is only valid with action='flag'"
-        flag_index = FLAG_COLORS.get(flag_color.strip().lower())
+        flag_color = flag_color.strip().lower()
+        flag_index = FLAG_COLORS.get(flag_color)
         if flag_index is None:
-            valid = ", ".join(sorted(set(FLAG_COLORS) - {"grey"}))
+            valid = ", ".join(c for c in FLAG_COLORS if c != "grey")
             return f"Error: Invalid flag_color '{flag_color}'. Use: {valid}"
 
     # Build action scripts
@@ -350,7 +351,7 @@ def update_email_status(
         if flag_index is not None:
             bulk_action_script = f"set flag index of targetMessages to {flag_index}"
             single_action_script = f"set flag index of aMessage to {flag_index}"
-            action_label = f"Flagged ({flag_color.strip().lower()})"
+            action_label = f"Flagged ({flag_color})"
         else:
             bulk_action_script = "set flagged status of targetMessages to true"
             single_action_script = "set flagged status of aMessage to true"

--- a/plugin/apple_mail_mcp/tools/manage.py
+++ b/plugin/apple_mail_mcp/tools/manage.py
@@ -4,8 +4,8 @@ import os
 from typing import Optional, List
 
 from apple_mail_mcp.server import mcp
-from apple_mail_mcp.constants import FLAG_COLORS
 from apple_mail_mcp.core import (
+    resolve_flag_color,
     contains_any_condition,
     equals_any_numeric_condition,
     inject_preferences,
@@ -333,10 +333,10 @@ def update_email_status(
         if action != "flag":
             return "Error: 'flag_color' is only valid with action='flag'"
         flag_color = flag_color.strip().lower()
-        flag_index = FLAG_COLORS.get(flag_color)
-        if flag_index is None:
-            valid = ", ".join(c for c in FLAG_COLORS if c != "grey")
-            return f"Error: Invalid flag_color '{flag_color}'. Use: {valid}"
+        try:
+            flag_index = resolve_flag_color(flag_color)
+        except ValueError as exc:
+            return f"Error: {exc}"
 
     # Build action scripts
     if action == "mark_read":

--- a/plugin/apple_mail_mcp/tools/manage.py
+++ b/plugin/apple_mail_mcp/tools/manage.py
@@ -349,8 +349,16 @@ def update_email_status(
         action_label = "Marked as unread"
     elif action == "flag":
         if flag_index is not None:
-            bulk_action_script = f"set flag index of targetMessages to {flag_index}"
-            single_action_script = f"set flag index of aMessage to {flag_index}"
+            # flag index and flagged status are independent properties; set
+            # both so coloring an unflagged message activates the flag.
+            bulk_action_script = (
+                f"set flag index of targetMessages to {flag_index}\n"
+                "                            set flagged status of targetMessages to true"
+            )
+            single_action_script = (
+                f"set flag index of aMessage to {flag_index}\n"
+                "                            set flagged status of aMessage to true"
+            )
             action_label = f"Flagged ({flag_color})"
         else:
             bulk_action_script = "set flagged status of targetMessages to true"
@@ -443,9 +451,12 @@ def update_email_status(
         conditions = ["read status is true"]
     elif action == "flag":
         if flag_index is not None:
-            # Unflagged messages have flag index -1, so this also matches
-            # already-flagged messages that need re-coloring.
-            conditions = [f"flag index is not {flag_index}"]
+            # Match unflagged messages AND already-flagged ones needing a
+            # re-color; also match a residual matching index whose flag is
+            # inactive (flag index survives unflagging).
+            conditions = [
+                f"(flag index is not {flag_index} or flagged status is false)"
+            ]
         else:
             conditions = ["flagged status is false"]
     else:  # unflag

--- a/plugin/apple_mail_mcp/tools/manage.py
+++ b/plugin/apple_mail_mcp/tools/manage.py
@@ -4,6 +4,7 @@ import os
 from typing import Optional, List
 
 from apple_mail_mcp.server import mcp
+from apple_mail_mcp.constants import FLAG_COLORS
 from apple_mail_mcp.core import (
     contains_any_condition,
     equals_any_numeric_condition,
@@ -298,6 +299,7 @@ def update_email_status(
     apply_to_all: bool = False,
     message_ids: Optional[List[str]] = None,
     older_than_days: Optional[int] = None,
+    flag_color: Optional[str] = None,
 ) -> str:
     """
     Update email status - mark as read/unread or flag/unflag emails.
@@ -316,12 +318,24 @@ def update_email_status(
         apply_to_all: Must be True to allow updates without any filter
         message_ids: Optional list of exact Mail message ids for precise targeting
         older_than_days: Optional age filter - only update emails older than N days
+        flag_color: Optional flag color for the "flag" action: "red", "orange",
+            "yellow", "green", "blue", "purple", or "gray". Omit for the default
+            red flag. Re-colors messages that are already flagged.
 
     Returns:
         Confirmation message with details of updated emails
     """
 
     safe_account = escape_applescript(account)
+
+    flag_index: Optional[int] = None
+    if flag_color is not None:
+        if action != "flag":
+            return "Error: 'flag_color' is only valid with action='flag'"
+        flag_index = FLAG_COLORS.get(flag_color.strip().lower())
+        if flag_index is None:
+            valid = ", ".join(sorted(set(FLAG_COLORS) - {"grey"}))
+            return f"Error: Invalid flag_color '{flag_color}'. Use: {valid}"
 
     # Build action scripts
     if action == "mark_read":
@@ -333,9 +347,14 @@ def update_email_status(
         single_action_script = "set read status of aMessage to false"
         action_label = "Marked as unread"
     elif action == "flag":
-        bulk_action_script = "set flagged status of targetMessages to true"
-        single_action_script = "set flagged status of aMessage to true"
-        action_label = "Flagged"
+        if flag_index is not None:
+            bulk_action_script = f"set flag index of targetMessages to {flag_index}"
+            single_action_script = f"set flag index of aMessage to {flag_index}"
+            action_label = f"Flagged ({flag_color.strip().lower()})"
+        else:
+            bulk_action_script = "set flagged status of targetMessages to true"
+            single_action_script = "set flagged status of aMessage to true"
+            action_label = "Flagged"
     elif action == "unflag":
         bulk_action_script = "set flagged status of targetMessages to false"
         single_action_script = "set flagged status of aMessage to false"
@@ -422,7 +441,12 @@ def update_email_status(
     elif action == "mark_unread":
         conditions = ["read status is true"]
     elif action == "flag":
-        conditions = ["flagged status is false"]
+        if flag_index is not None:
+            # Unflagged messages have flag index -1, so this also matches
+            # already-flagged messages that need re-coloring.
+            conditions = [f"flag index is not {flag_index}"]
+        else:
+            conditions = ["flagged status is false"]
     else:  # unflag
         conditions = ["flagged status is true"]
 

--- a/plugin/apple_mail_mcp/tools/manage.py
+++ b/plugin/apple_mail_mcp/tools/manage.py
@@ -319,8 +319,10 @@ def update_email_status(
         message_ids: Optional list of exact Mail message ids for precise targeting
         older_than_days: Optional age filter - only update emails older than N days
         flag_color: Optional flag color for the "flag" action: "red", "orange",
-            "yellow", "green", "blue", "purple", or "gray". Omit for the default
-            red flag. Re-colors messages that are already flagged.
+            "yellow", "green", "blue", "purple", or "gray". Omit to flag
+            without setting a color — Mail shows its default (red), or the
+            message's previous color if one remains from an earlier flag.
+            Re-colors messages that are already flagged.
 
     Returns:
         Confirmation message with details of updated emails

--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -239,7 +239,11 @@ def _search_mail_records(
             else:
                 filter_conditions.append("(count of mail attachments) = 0")
         if flag_index is not None:
-            filter_conditions.append(f"flag index is {flag_index}")
+            # flag index survives unflagging; require the active-flag boolean
+            # so residual indexes on unflagged messages don't match.
+            filter_conditions.append(
+                f"(flagged status is true and flag index is {flag_index})"
+            )
         elif flagged is not None:
             filter_conditions.append(
                 f"flagged status is {'true' if flagged else 'false'}"

--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Dict, Any
 from urllib.parse import quote
 
 from apple_mail_mcp.server import mcp
+from apple_mail_mcp.constants import FLAG_COLORS, FLAG_COLOR_NAMES
 from apple_mail_mcp.core import (
     contains_any_condition,
     inject_preferences,
@@ -63,11 +64,15 @@ def _parse_search_records(output: str) -> List[Dict[str, Any]]:
 
     records = []
     for line in output.splitlines():
-        parts = line.split("|||", 8)
-        if len(parts) < 8:
+        parts = line.split("|||", 9)
+        if len(parts) < 9:
             continue
 
         internet_message_id = parts[1].strip()
+        try:
+            flag_index = int(parts[8].strip())
+        except ValueError:
+            flag_index = -1
         record = {
             "message_id": parts[0].strip(),
             "internet_message_id": internet_message_id,
@@ -77,15 +82,18 @@ def _parse_search_records(output: str) -> List[Dict[str, Any]]:
             "account": parts[5].strip(),
             "is_read": parts[6].strip().lower() == "true",
             "received_date": parts[7].strip(),
+            "is_flagged": flag_index >= 0,
         }
+        if flag_index in FLAG_COLOR_NAMES:
+            record["flag_color"] = FLAG_COLOR_NAMES[flag_index]
         if internet_message_id:
             # Apple Mail requires: message:// scheme, angle brackets (percent-encoded),
             # and raw @ in the Message-ID. Normalize ID in case angle brackets are
             # present or missing (AppleScript returns both forms).
             msg_id = internet_message_id.strip("<>")
             record["mail_link"] = f"message://%3C{quote(msg_id, safe='@')}%3E"
-        if len(parts) > 8 and parts[8].strip():
-            record["content_preview"] = parts[8].strip()
+        if len(parts) > 9 and parts[9].strip():
+            record["content_preview"] = parts[9].strip()
         records.append(record)
 
     return records
@@ -118,7 +126,12 @@ def _format_search_records_text(
         lines.append("")
         for item in records:
             indicator = "\u2713" if item["is_read"] else "\u2709"
-            lines.append(f"{indicator} {item['subject']}")
+            subject_line = f"{indicator} {item['subject']}"
+            if item.get("flag_color"):
+                subject_line += f" \u2691 {item['flag_color']}"
+            elif item.get("is_flagged"):
+                subject_line += " \u2691"
+            lines.append(subject_line)
             lines.append(f"   From: {item['sender']}")
             lines.append(f"   Date: {item['received_date']}")
             lines.append(f"   Mailbox: {item['mailbox']}")
@@ -170,6 +183,8 @@ def _search_mail_records(
     subject_terms: Optional[List[str]] = None,
     sender: Optional[str] = None,
     has_attachments: Optional[bool] = None,
+    flagged: Optional[bool] = None,
+    flag_color: Optional[str] = None,
     read_status: str = "all",
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
@@ -195,6 +210,18 @@ def _search_mail_records(
     if read_status not in {"all", "read", "unread"}:
         raise ValueError("Invalid read_status. Use: all, read, unread")
 
+    flag_index: Optional[int] = None
+    if flag_color is not None:
+        flag_index = FLAG_COLORS.get(flag_color.strip().lower())
+        if flag_index is None:
+            valid = ", ".join(c for c in FLAG_COLORS if c != "grey")
+            raise ValueError(f"Invalid flag_color '{flag_color}'. Use: {valid}")
+        if flagged is False:
+            raise ValueError(
+                "flag_color cannot be combined with flagged=False "
+                "(a colored flag implies the message is flagged)"
+            )
+
     escaped_sender = escape_applescript(sender) if sender else None
 
     # When body_text is provided, we must iterate per-message (can't use whose clause)
@@ -212,6 +239,12 @@ def _search_mail_records(
                 filter_conditions.append("(count of mail attachments) > 0")
             else:
                 filter_conditions.append("(count of mail attachments) = 0")
+        if flag_index is not None:
+            filter_conditions.append(f"flag index is {flag_index}")
+        elif flagged is not None:
+            filter_conditions.append(
+                f"flagged status is {'true' if flagged else 'false'}"
+            )
         if read_status == "read":
             filter_conditions.append("read status is true")
         elif read_status == "unread":
@@ -297,6 +330,12 @@ def _search_mail_records(
             per_msg_conditions.append("(count of mail attachments of aMessage) > 0")
         elif has_attachments is False:
             per_msg_conditions.append("(count of mail attachments of aMessage) = 0")
+        if flag_index is not None:
+            per_msg_conditions.append(f"messageFlagIndex is {flag_index}")
+        elif flagged is True:
+            per_msg_conditions.append("messageFlagIndex is not -1")
+        elif flagged is False:
+            per_msg_conditions.append("messageFlagIndex is -1")
 
         # Body text condition is always present in body search mode
         per_msg_conditions.append(f'lowerContent contains "{escaped_body}"')
@@ -313,6 +352,10 @@ def _search_mail_records(
                                     set messageSender to sender of aMessage
                                     set messageRead to read status of aMessage
                                     set messageDate to date received of aMessage
+                                    set messageFlagIndex to -1
+                                    try
+                                        set messageFlagIndex to flag index of aMessage
+                                    end try
                                     set lowerSubject to my lowercase(messageSubject)
                                     set lowerSender to my lowercase(messageSender)
                                     set msgContent to ""
@@ -438,6 +481,10 @@ def _search_mail_records(
                                                 set messageRead to read status of aMessage
                                                 set messageDate to date received of aMessage
                                                 set receivedAt to my iso_datetime(messageDate)
+                                                set messageFlagIndex to -1
+                                                try
+                                                    set messageFlagIndex to flag index of aMessage
+                                                end try
                                                 set contentPreview to ""
 
                                                 if {str(include_content).lower()} then
@@ -463,7 +510,7 @@ def _search_mail_records(
                                                     set readValue to "true"
                                                 end if
 
-                                                set recordLine to messageId & "|||" & internetMessageId & "|||" & messageSubject & "|||" & messageSender & "|||" & mailboxName & "|||" & accountName & "|||" & readValue & "|||" & receivedAt & "|||" & contentPreview
+                                                set recordLine to messageId & "|||" & internetMessageId & "|||" & messageSubject & "|||" & messageSender & "|||" & mailboxName & "|||" & accountName & "|||" & readValue & "|||" & receivedAt & "|||" & (messageFlagIndex as string) & "|||" & contentPreview
                                                 set end of recordLines to recordLine
                                                 set collectLimit to collectLimit - 1
                                                 if collectLimit <= 0 then exit repeat
@@ -511,6 +558,8 @@ def search_emails(
     subject_keywords: Optional[List[str]] = None,
     sender: Optional[str] = None,
     has_attachments: Optional[bool] = None,
+    flagged: Optional[bool] = None,
+    flag_color: Optional[str] = None,
     read_status: str = "all",
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
@@ -537,6 +586,9 @@ def search_emails(
         subject_keywords: Optional list of subject keywords; matches any keyword
         sender: Optional sender email or name to filter by
         has_attachments: Optional filter for emails with attachments (True/False/None)
+        flagged: Optional filter for flagged emails (True/False/None)
+        flag_color: Optional filter for a specific flag color: "red", "orange",
+            "yellow", "green", "blue", "purple", or "gray". Implies flagged=True.
         read_status: Filter by read status: "all", "read", "unread" (default: "all")
         date_from: Optional start date filter (format: "YYYY-MM-DD")
         date_to: Optional end date filter (format: "YYYY-MM-DD")
@@ -568,6 +620,8 @@ def search_emails(
             subject_terms=subject_terms,
             sender=sender,
             has_attachments=has_attachments,
+            flagged=flagged,
+            flag_color=flag_color,
             read_status=read_status,
             date_from=date_from,
             date_to=date_to,

--- a/plugin/apple_mail_mcp/tools/search.py
+++ b/plugin/apple_mail_mcp/tools/search.py
@@ -7,12 +7,14 @@ from typing import Optional, List, Dict, Any
 from urllib.parse import quote
 
 from apple_mail_mcp.server import mcp
-from apple_mail_mcp.constants import FLAG_COLORS, FLAG_COLOR_NAMES
+from apple_mail_mcp.constants import FLAG_COLOR_NAMES
 from apple_mail_mcp.core import (
     contains_any_condition,
     inject_preferences,
     escape_applescript,
     normalize_search_terms,
+    resolve_flag_color,
+    read_flag_index_script,
     run_applescript,
     LOWERCASE_HANDLER,
 )
@@ -212,10 +214,7 @@ def _search_mail_records(
 
     flag_index: Optional[int] = None
     if flag_color is not None:
-        flag_index = FLAG_COLORS.get(flag_color.strip().lower())
-        if flag_index is None:
-            valid = ", ".join(c for c in FLAG_COLORS if c != "grey")
-            raise ValueError(f"Invalid flag_color '{flag_color}'. Use: {valid}")
+        flag_index = resolve_flag_color(flag_color)
         if flagged is False:
             raise ValueError(
                 "flag_color cannot be combined with flagged=False "
@@ -307,6 +306,10 @@ def _search_mail_records(
     # Build body search per-message filter block
     if use_body_search:
         escaped_body = escape_applescript(body_text.lower()) if body_text else ""
+        # Only pay the per-message flag-index read when a flag filter needs it.
+        flag_read_script = ""
+        if flag_index is not None or flagged is not None:
+            flag_read_script = read_flag_index_script()
         # Build per-message conditions for subject, sender, read_status, dates, attachments
         per_msg_conditions = []
         if subject_terms:
@@ -352,10 +355,7 @@ def _search_mail_records(
                                     set messageSender to sender of aMessage
                                     set messageRead to read status of aMessage
                                     set messageDate to date received of aMessage
-                                    set messageFlagIndex to -1
-                                    try
-                                        set messageFlagIndex to flag index of aMessage
-                                    end try
+                                    {flag_read_script}
                                     set lowerSubject to my lowercase(messageSubject)
                                     set lowerSender to my lowercase(messageSender)
                                     set msgContent to ""
@@ -481,10 +481,7 @@ def _search_mail_records(
                                                 set messageRead to read status of aMessage
                                                 set messageDate to date received of aMessage
                                                 set receivedAt to my iso_datetime(messageDate)
-                                                set messageFlagIndex to -1
-                                                try
-                                                    set messageFlagIndex to flag index of aMessage
-                                                end try
+                                                {read_flag_index_script()}
                                                 set contentPreview to ""
 
                                                 if {str(include_content).lower()} then

--- a/plugin/apple_mail_mcp/tools/smart_inbox.py
+++ b/plugin/apple_mail_mcp/tools/smart_inbox.py
@@ -6,6 +6,7 @@ from apple_mail_mcp.server import mcp
 from apple_mail_mcp.core import (
     inject_preferences,
     escape_applescript,
+    read_flag_index_script,
     run_applescript,
     inbox_mailbox_script,
     date_cutoff_script,
@@ -308,6 +309,7 @@ def get_needs_response(
             set highPriority to {{}}
             set normalPriority to {{}}
             set totalChecked to 0
+            set flagColorNames to {{{_FLAG_COLOR_NAME_LIST}}}
 
             repeat with aMessage in mailboxMessages
                 if (count of highPriority) + (count of normalPriority) >= {max_results} then exit repeat
@@ -349,14 +351,10 @@ def get_needs_response(
                                     if msgContent contains "?" then set hasQuestion to true
                                 end try
 
-                                set flagIndex to -1
-                                try
-                                    set flagIndex to flag index of aMessage
-                                end try
+                                {read_flag_index_script("flagIndex")}
                                 set isFlagged to (flagIndex is not -1)
                                 set flagLabel to "flagged"
                                 if flagIndex >= 0 and flagIndex < 7 then
-                                    set flagColorNames to {{{_FLAG_COLOR_NAME_LIST}}}
                                     set flagLabel to "flagged " & item (flagIndex + 1) of flagColorNames
                                 end if
 

--- a/plugin/apple_mail_mcp/tools/smart_inbox.py
+++ b/plugin/apple_mail_mcp/tools/smart_inbox.py
@@ -15,6 +15,13 @@ from apple_mail_mcp.constants import (
     NEWSLETTER_PLATFORM_PATTERNS,
     NEWSLETTER_KEYWORD_PATTERNS,
     THREAD_PREFIXES,
+    FLAG_COLOR_NAMES,
+)
+
+# AppleScript list literal of color names indexed by flag index, e.g.
+# {"red", "orange", ...} — item (flagIndex + 1) of this list is the name.
+_FLAG_COLOR_NAME_LIST = ", ".join(
+    f'"{FLAG_COLOR_NAMES[i]}"' for i in sorted(FLAG_COLOR_NAMES)
 )
 
 
@@ -342,17 +349,23 @@ def get_needs_response(
                                     if msgContent contains "?" then set hasQuestion to true
                                 end try
 
-                                set isFlagged to false
+                                set flagIndex to -1
                                 try
-                                    set isFlagged to flagged status of aMessage
+                                    set flagIndex to flag index of aMessage
                                 end try
+                                set isFlagged to (flagIndex is not -1)
+                                set flagLabel to "flagged"
+                                if flagIndex >= 0 and flagIndex < 7 then
+                                    set flagColorNames to {{{_FLAG_COLOR_NAME_LIST}}}
+                                    set flagLabel to "flagged " & item (flagIndex + 1) of flagColorNames
+                                end if
 
                                 set emailEntry to messageSubject & "|||" & messageSender & "|||" & (messageDate as string) & "|||"
                                 if hasQuestion or isFlagged then
                                     if hasQuestion and isFlagged then
-                                        set emailEntry to emailEntry & "HIGH (flagged + question)"
+                                        set emailEntry to emailEntry & "HIGH (" & flagLabel & " + question)"
                                     else if isFlagged then
-                                        set emailEntry to emailEntry & "HIGH (flagged)"
+                                        set emailEntry to emailEntry & "HIGH (" & flagLabel & ")"
                                     else
                                         set emailEntry to emailEntry & "MEDIUM (contains question)"
                                     end if

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -316,8 +316,9 @@ class SearchToolTests(unittest.TestCase):
         with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
             search_tools.search_emails(account="Work", flag_color="purple")
 
-        self.assertIn("flag index is 5", captured["script"])
-        self.assertNotIn("flagged status", captured["script"])
+        self.assertIn(
+            "(flagged status is true and flag index is 5)", captured["script"]
+        )
 
     def test_search_emails_flag_color_in_body_search_path(self):
         captured = {}
@@ -412,7 +413,8 @@ class ManageToolTests(unittest.TestCase):
         self.assertEqual(result, "updated")
         self.assertIn("set flag index of targetMessages to 1", captured["script"])
         self.assertIn("Flagged (orange)", captured["script"])
-        self.assertNotIn("set flagged status", captured["script"])
+        # flag index alone doesn't activate the flag; both must be set.
+        self.assertIn("set flagged status of targetMessages to true", captured["script"])
 
     def test_update_email_status_flag_without_color_uses_flagged_status(self):
         captured = {}
@@ -448,8 +450,11 @@ class ManageToolTests(unittest.TestCase):
                 flag_color="green",
             )
 
-        self.assertIn("flag index is not 3", captured["script"])
+        self.assertIn(
+            "(flag index is not 3 or flagged status is false)", captured["script"]
+        )
         self.assertIn("set flag index of aMessage to 3", captured["script"])
+        self.assertIn("set flagged status of aMessage to true", captured["script"])
 
     def test_update_email_status_rejects_invalid_flag_color(self):
         with patch("apple_mail_mcp.tools.manage.run_applescript") as mock_run:

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -281,6 +281,90 @@ class ManageToolTests(unittest.TestCase):
         self.assertIn("id is 202", captured["script"])
         self.assertIn("set read status of targetMessages to true", captured["script"])
 
+    def test_update_email_status_flag_color_sets_flag_index(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return "updated"
+
+        with patch("apple_mail_mcp.tools.manage.run_applescript", side_effect=fake_run):
+            result = manage_tools.update_email_status(
+                account="Work",
+                mailbox="INBOX",
+                message_ids=["101"],
+                action="flag",
+                flag_color="Orange",
+            )
+
+        self.assertEqual(result, "updated")
+        self.assertIn("set flag index of targetMessages to 1", captured["script"])
+        self.assertIn("Flagged (orange)", captured["script"])
+        self.assertNotIn("set flagged status", captured["script"])
+
+    def test_update_email_status_flag_without_color_uses_flagged_status(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return "updated"
+
+        with patch("apple_mail_mcp.tools.manage.run_applescript", side_effect=fake_run):
+            manage_tools.update_email_status(
+                account="Work",
+                mailbox="INBOX",
+                message_ids=["101"],
+                action="flag",
+            )
+
+        self.assertIn("set flagged status of targetMessages to true", captured["script"])
+        self.assertNotIn("flag index", captured["script"])
+
+    def test_update_email_status_flag_color_filter_path_matches_other_colors(self):
+        captured = {}
+
+        def fake_run(script, timeout=300):
+            captured["script"] = script
+            return "updated"
+
+        with patch("apple_mail_mcp.tools.manage.run_applescript", side_effect=fake_run):
+            manage_tools.update_email_status(
+                account="Work",
+                mailbox="INBOX",
+                subject_keyword="invoice",
+                action="flag",
+                flag_color="green",
+            )
+
+        self.assertIn("flag index is not 3", captured["script"])
+        self.assertIn("set flag index of aMessage to 3", captured["script"])
+
+    def test_update_email_status_rejects_invalid_flag_color(self):
+        with patch("apple_mail_mcp.tools.manage.run_applescript") as mock_run:
+            result = manage_tools.update_email_status(
+                account="Work",
+                mailbox="INBOX",
+                message_ids=["101"],
+                action="flag",
+                flag_color="magenta",
+            )
+
+        self.assertIn("Invalid flag_color", result)
+        mock_run.assert_not_called()
+
+    def test_update_email_status_rejects_flag_color_with_other_actions(self):
+        with patch("apple_mail_mcp.tools.manage.run_applescript") as mock_run:
+            result = manage_tools.update_email_status(
+                account="Work",
+                mailbox="INBOX",
+                message_ids=["101"],
+                action="mark_read",
+                flag_color="red",
+            )
+
+        self.assertIn("only valid with action='flag'", result)
+        mock_run.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -332,7 +332,28 @@ class SearchToolTests(unittest.TestCase):
             )
 
         self.assertIn("messageFlagIndex is 0", captured["script"])
-        self.assertIn("set messageFlagIndex to flag index of aMessage", captured["script"])
+        # Read in both the scan loop and the record emission block.
+        self.assertEqual(
+            captured["script"].count("set messageFlagIndex to flag index of aMessage"),
+            2,
+        )
+
+    def test_search_emails_body_search_skips_flag_read_without_flag_filter(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            search_tools.search_emails(account="Work", body_text="invoice")
+
+        # Only the record emission block reads flag index; the per-message
+        # scan loop must not pay for it when no flag filter is set.
+        self.assertEqual(
+            captured["script"].count("set messageFlagIndex to flag index of aMessage"),
+            1,
+        )
 
     def test_search_emails_rejects_invalid_flag_color(self):
         with patch("apple_mail_mcp.tools.search.run_applescript") as mock_run:

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from apple_mail_mcp.tools import manage as manage_tools
 from apple_mail_mcp.tools import search as search_tools
+from apple_mail_mcp.tools import smart_inbox as smart_inbox_tools
 
 
 def _record_line(
@@ -17,6 +18,7 @@ def _record_line(
     account="Work",
     is_read=False,
     received_date="2026-03-07T10:00:00",
+    flag_index=-1,
     content_preview="",
 ):
     return "|||".join(
@@ -29,6 +31,7 @@ def _record_line(
             account,
             "true" if is_read else "false",
             received_date,
+            str(flag_index),
             content_preview,
         ]
     )
@@ -259,6 +262,94 @@ class SearchToolTests(unittest.TestCase):
         self.assertIn("on lowercase(str)", captured["script"])
         self.assertIn('lowerContent contains "invoice"', captured["script"])
 
+    def test_search_emails_reports_flag_color(self):
+        def fake_run(script, timeout=120):
+            return "\n".join(
+                [
+                    _record_line(100, "Flagged orange", flag_index=1),
+                    _record_line(101, "Not flagged", flag_index=-1),
+                ]
+            )
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            result = search_tools.search_emails(
+                account="Work",
+                output_format="json",
+            )
+
+        items = json.loads(result)["items"]
+        flagged_item = next(i for i in items if i["message_id"] == "100")
+        plain_item = next(i for i in items if i["message_id"] == "101")
+        self.assertTrue(flagged_item["is_flagged"])
+        self.assertEqual(flagged_item["flag_color"], "orange")
+        self.assertFalse(plain_item["is_flagged"])
+        self.assertNotIn("flag_color", plain_item)
+
+    def test_search_emails_text_output_shows_flag_marker(self):
+        def fake_run(script, timeout=120):
+            return _record_line(100, "Budget review", flag_index=3)
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            result = search_tools.search_emails(account="Work")
+
+        self.assertIn("Budget review ⚑ green", result)
+
+    def test_search_emails_flagged_filter_builds_whose_clause(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            search_tools.search_emails(account="Work", flagged=True)
+
+        self.assertIn("flagged status is true", captured["script"])
+
+    def test_search_emails_flag_color_filter_uses_flag_index(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            search_tools.search_emails(account="Work", flag_color="purple")
+
+        self.assertIn("flag index is 5", captured["script"])
+        self.assertNotIn("flagged status", captured["script"])
+
+    def test_search_emails_flag_color_in_body_search_path(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.search.run_applescript", side_effect=fake_run):
+            search_tools.search_emails(
+                account="Work", body_text="invoice", flag_color="red"
+            )
+
+        self.assertIn("messageFlagIndex is 0", captured["script"])
+        self.assertIn("set messageFlagIndex to flag index of aMessage", captured["script"])
+
+    def test_search_emails_rejects_invalid_flag_color(self):
+        with patch("apple_mail_mcp.tools.search.run_applescript") as mock_run:
+            result = search_tools.search_emails(account="Work", flag_color="magenta")
+
+        self.assertIn("Invalid flag_color", result)
+        mock_run.assert_not_called()
+
+    def test_search_emails_rejects_flag_color_with_flagged_false(self):
+        with patch("apple_mail_mcp.tools.search.run_applescript") as mock_run:
+            result = search_tools.search_emails(
+                account="Work", flagged=False, flag_color="blue"
+            )
+
+        self.assertIn("flag_color cannot be combined", result)
+        mock_run.assert_not_called()
+
 
 class ManageToolTests(unittest.TestCase):
     def test_update_email_status_with_message_ids_uses_exact_id_condition(self):
@@ -364,6 +455,27 @@ class ManageToolTests(unittest.TestCase):
 
         self.assertIn("only valid with action='flag'", result)
         mock_run.assert_not_called()
+
+
+class SmartInboxToolTests(unittest.TestCase):
+    def test_get_needs_response_priority_label_includes_flag_color(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return "no results"
+
+        with patch(
+            "apple_mail_mcp.tools.smart_inbox.run_applescript", side_effect=fake_run
+        ):
+            smart_inbox_tools.get_needs_response(account="Work")
+
+        self.assertIn("set flagIndex to flag index of aMessage", captured["script"])
+        self.assertIn(
+            'set flagColorNames to {"red", "orange", "yellow", "green", "blue", "purple", "gray"}',
+            captured["script"],
+        )
+        self.assertIn('"HIGH (" & flagLabel & " + question)"', captured["script"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Apple Mail's AppleScript dictionary exposes `flag index` (-1 = unflagged; 0–6 = red, orange, yellow, green, blue, purple, gray), but the server only used the boolean `flagged status`, so flags were red-only and write-only. Notably, the MCPB manifest already advertised a "flagged" filter for `search_emails` that didn't exist yet — this PR implements it, with colors.

- **Set**: `update_email_status` gains `flag_color` for the `flag` action. It sets both `flag index` and `flagged status` (the two are independent properties — unflagging clears only the boolean, leaving a residual index). The filter-path no-op guard becomes `(flag index is not N or flagged status is false)` so already-flagged messages can be re-colored. The no-color path is unchanged.
- **Report**: `search_emails` records now carry `is_flagged` and `flag_color` (JSON), sourced from a new flag-index field in the record line; text output marks flagged rows with `⚑ <color>`.
- **Query**: new `search_emails` filters `flagged` (tri-state, like `has_attachments`) and `flag_color` (implies flagged; rejected when combined with `flagged=False`), implemented in both the whose-clause path and the body-search path. Color conditions require `flagged status is true` so residual indexes on unflagged messages never match.
- **Smart inbox**: `get_needs_response` priority labels include the color, e.g. `HIGH (flagged orange + question)`.

Shared plumbing: `FLAG_COLORS`/`FLAG_COLOR_NAMES` in constants.py, `resolve_flag_color()` validation and a `read_flag_index_script()` AppleScript helper in core.py (the helper gates the index read on `flagged status`, keeping reporting, body search, and smart inbox consistent). The body-search loop only pays the per-message flag-index read when a flag filter is set.

Custom flag *names* assigned in Mail's UI are not scriptable; only the seven indexed colors are supported (`grey` accepted as an input alias for `gray`).

## Testing

- 96 unit tests pass (`PYTHONPATH=plugin python -m pytest tests/`), including 16 new ones covering set/report/query paths, validation errors, the flagged-status gating, and the conditional flag read.
- Verified live via Claude Desktop against real mailboxes: setting colored flags, color reporting in search results, and color-filtered search.
- Pre-reviewed: this branch went through two rounds of AI review (Codex, CodeRabbit, Gemini) on [samalone#1](https://github.com/samalone/apple-mail-mcp/pull/1); findings (including the flag index / flagged status independence) are addressed in the later commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)