### PR TITLE
fix: ship 3.x to PyPI + add CI/release guards so the packaging bug can't regress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Version drift guard
+        run: python scripts/check_versions.py
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest fastmcp
+
+      - name: Run test suite
+        env:
+          PYTHONPATH: plugin
+        run: python -m pytest tests/ -q
+
+  build-and-verify:
+    name: Build wheel + verify packaging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      # This is the guard against the 2.2.0-style regression: a wheel that
+      # ships only dist-info and the console script but NOT the
+      # apple_mail_mcp/ package. verify_wheel.py inspects the artifact and
+      # does a clean-venv install + import + entry-point check.
+      - name: Verify the built wheel is installable & contains the package
+        run: python scripts/verify_wheel.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+# Publishes mcp-apple-mail to PyPI via Trusted Publishing (OIDC — no API
+# tokens stored in the repo). Triggered by pushing a version tag, e.g.:
+#
+#     git tag v3.1.7 && git push origin v3.1.7
+#
+# The build job fails closed if the tag does not match the pyproject version,
+# if the version strings drift, or if the wheel is missing the package. Only a
+# verified-healthy artifact reaches the publish job.
+#
+# One-time setup (PyPI side) is documented in RELEASING.md.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build + verify artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Version drift guard
+        run: python scripts/check_versions.py
+
+      - name: Guard — git tag must match pyproject version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          VER=$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          echo "tag=$TAG  pyproject=$VER"
+          if [ "$TAG" != "$VER" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match pyproject version $VER — refusing to publish."
+            exit 1
+          fi
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Verify wheel (structure + clean-venv install + entry point)
+        run: python scripts/verify_wheel.py
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mcp-apple-mail
+    permissions:
+      id-token: write # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to **mcp-apple-mail** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.1.7] - 2026-06-12
+
+First 3.x release actually published to PyPI. Versions 3.0.0–3.1.6 were tagged
+in git but never uploaded, so PyPI remained stuck on the broken 2.2.0 wheel and
+`uvx mcp-apple-mail` kept failing with `ModuleNotFoundError: No module named
+'apple_mail_mcp'`. This release ships the (already-correct) `plugin/` packaging
+to PyPI and adds automation so a release can never again be built-but-not-shipped.
+
+### Fixed
+- **PyPI now serves a working wheel** that contains the `apple_mail_mcp/`
+  package. Resolves the user-facing failure reported in #42 and #57.
+
+### Added
+- **Release automation via PyPI Trusted Publishing** (`.github/workflows/release.yml`).
+  Pushing a `vX.Y.Z` tag builds, verifies, and publishes via OIDC — no API
+  tokens stored. The build fails closed if the tag doesn't match the version or
+  the wheel is missing the package.
+- **CI packaging guard** (`.github/workflows/ci.yml`) — every push/PR builds the
+  wheel and runs `verify_wheel.py`, plus the test suite on Python 3.10–3.13.
+- **`scripts/verify_wheel.py`** — pre-publish artifact guard. Inspects a wheel
+  for the `apple_mail_mcp/` package and payload size, then does a clean-venv
+  install + import + entry-point check. Catches the 2.2.0-style "dist-info only"
+  regression before it ships.
+- **This `CHANGELOG.md`** (previously linked from `pyproject.toml` but missing)
+  and **`RELEASING.md`** documenting the release flow and one-time PyPI setup.
+
+### Notes
+- The README's `uvx mcp-apple-mail` package name is correct — `mcp-apple-mail`
+  is this project's PyPI distribution. (The similarly named `apple-mail-mcp` on
+  PyPI is an unrelated package by a different author.) Issue #57's suggested
+  rename would have pointed users at the wrong package, so it was not applied.
+
+## [3.0.0] – [3.1.6] - 2026-03-27 → 2026-06-09 (git tags only, never on PyPI)
+
+These versions were released as GitHub tags/MCPB bundles but were never uploaded
+to PyPI. Highlights from this line, now reaching PyPI users via 3.1.7:
+
+### Fixed
+- Corrected `pyproject.toml` for the `plugin/` package layout so the wheel
+  includes the `apple_mail_mcp/` package (the root fix for the 2.2.0 bug).
+- Stop a Mail relaunch loop; prevent orphaned `osascript` from pinning Mail's
+  main thread; poll for Mail focus before pasting to avoid silent empty sends.
+- Attach files after the HTML paste so `Cmd+A` doesn't clobber them; scope
+  `reply_to_email` attachment inserts to the reply message.
+- Produce working Apple Mail deep links from search results; strip CDATA
+  wrappers from body content; support localized inbox names (FR/DE/ES/IT/PT/NL/JA).
+- Respect account default sender and allow `from_address` override.
+
+### Added
+- `synchronize_account` and `list_account_addresses` tools; `mail_link` in
+  default search output.
+- Version drift guard (`scripts/check_versions.py`) and `server.json` for MCP
+  Registry validation.
+- Plugin/marketplace distribution layout (`plugin/`), `/email-management` slash
+  command.
+
+### Changed
+- Consolidated tools: 10 search tools → 2 (`search_emails` + `get_email_thread`);
+  merged bulk operations into `manage.py`; trimmed verbose tool responses.
+
+## [2.2.0] - 2026-03-27 (broken on PyPI — superseded by 3.1.7)
+
+> **Do not use.** This wheel shipped only the dist-info and console-script entry
+> point, not the `apple_mail_mcp/` package, so the server crashes on startup
+> with `ModuleNotFoundError`. Fixed in 3.1.7. (Reported in #42, #57.)
+
+[3.1.7]: https://github.com/patrickfreyer/apple-mail-mcp/releases/tag/v3.1.7
+[2.2.0]: https://github.com/patrickfreyer/apple-mail-mcp/releases/tag/v2.2.0

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ claude mcp add apple-mail -- mcp-apple-mail
 <details>
 <summary><strong>Claude Desktop MCPB</strong></summary>
 
-1. Download `apple-mail-mcp-v2.2.0.mcpb` from [Releases](https://github.com/patrickfreyer/apple-mail-mcp/releases)
+1. Download the latest `apple-mail-mcp-vX.Y.Z.mcpb` from [Releases](https://github.com/patrickfreyer/apple-mail-mcp/releases)
 2. Open Claude Desktop → Settings → Developer → MCP Servers → Install from file
 3. Select the `.mcpb` file and grant Mail.app permissions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,74 @@
+# Releasing `mcp-apple-mail`
+
+Releases are published to PyPI automatically by GitHub Actions using **PyPI
+Trusted Publishing** (OIDC). No API tokens are stored anywhere.
+
+## Background — why this exists
+
+The `2.2.0` PyPI wheel shipped without the `apple_mail_mcp/` package (dist-info
+only), so `uvx mcp-apple-mail` failed with `ModuleNotFoundError`. The fix landed
+in the `3.1.x` line but was only ever **git-tagged, never uploaded** — PyPI sat
+on the broken `2.2.0` for months. This automation makes "tagged but not shipped"
+impossible: the same tag that marks a release also triggers the publish.
+
+## One-time setup (do this once, on PyPI)
+
+The release workflow can't publish until PyPI trusts it. Configure the trusted
+publisher:
+
+1. Sign in to <https://pypi.org> as the `mcp-apple-mail` project owner.
+2. Go to the project: **Your projects → mcp-apple-mail → Settings → Publishing**
+   (`https://pypi.org/manage/project/mcp-apple-mail/settings/publishing/`).
+3. Under **Add a new trusted publisher → GitHub**, enter exactly:
+   - **Owner:** `patrickfreyer`
+   - **Repository name:** `apple-mail-mcp`
+   - **Workflow name:** `release.yml`
+   - **Environment name:** `pypi`
+4. Save.
+
+> The `environment name` must be `pypi` to match `environment: name: pypi` in
+> `.github/workflows/release.yml`. Optionally add a GitHub environment protection
+> rule (Settings → Environments → `pypi` → required reviewers) so a release
+> pauses for manual approval before the upload step.
+
+## Cutting a release
+
+1. Make sure `main` is green (CI builds the wheel and runs `verify_wheel.py`).
+2. Bump the version in **all** tracked files (they must agree — CI enforces it):
+   - `pyproject.toml`
+   - `server.json` (two places: top-level and `packages[0].version`)
+   - `apple-mail-mcpb/manifest.json`
+   - `plugin/apple_mail_mcp/__init__.py`
+
+   Then confirm:
+   ```bash
+   python scripts/check_versions.py
+   ```
+3. Update `CHANGELOG.md` with the new version section.
+4. Merge to `main`, then tag and push:
+   ```bash
+   git tag v3.1.7
+   git push origin v3.1.7
+   ```
+5. The **Release** workflow runs automatically: it checks the tag matches the
+   version, builds, runs `verify_wheel.py`, and publishes to PyPI.
+6. Confirm: `uvx mcp-apple-mail` (or `pip install -U mcp-apple-mail`) pulls the
+   new version and starts cleanly.
+
+## Verifying a build locally (before tagging)
+
+```bash
+python -m build
+python scripts/verify_wheel.py        # structure + clean-venv install + entry point
+unzip -l dist/*.whl                    # eyeball: must list apple_mail_mcp/ files
+```
+
+A healthy wheel is a few hundred KB. A ~6 KB wheel is the broken "dist-info only"
+shape — do not publish it.
+
+## Package naming (important)
+
+This project's PyPI distribution is **`mcp-apple-mail`**. The import package is
+`apple_mail_mcp` and the console script is `mcp-apple-mail`. These are correct
+and consistent — do **not** rename to `apple-mail-mcp`, which is an unrelated
+package by a different author already on PyPI.

--- a/apple-mail-mcpb/manifest.json
+++ b/apple-mail-mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "Apple Mail MCP",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Natural language interface for Apple Mail with 27 tools — email search, composition, bulk operations, smart inbox analytics, folder management, and security-hardened destructive operations. Includes Email Management Expert Skill and Interactive UI Dashboard.",
   "author": {
     "name": "Patrick Freyer"

--- a/plugin/apple_mail_mcp/__init__.py
+++ b/plugin/apple_mail_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Apple Mail MCP - Modular package."""
 
-__version__ = "3.1.6"
+__version__ = "3.1.7"
 
 from apple_mail_mcp.server import mcp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-apple-mail"
-version = "3.1.6"
+version = "3.1.7"
 description = "MCP server giving AI assistants full access to Apple Mail - read, search, compose, organize & analyze emails"
 readme = "README.md"
 license = "MIT"

--- a/scripts/verify_wheel.py
+++ b/scripts/verify_wheel.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+verify_wheel.py — Pre-publish artifact guard.
+
+Catches the exact class of bug that shipped in the broken 2.2.0 PyPI release:
+a wheel that contains only the dist-info + console-script entry point but NOT
+the apple_mail_mcp/ package (so `uvx mcp-apple-mail` dies with
+ModuleNotFoundError: No module named 'apple_mail_mcp').
+
+What it checks, given a built wheel:
+  1. STRUCTURE — the wheel actually contains apple_mail_mcp/__init__.py,
+     apple_mail_mcp/__main__.py, and a healthy number of module files.
+  2. SIZE — the package payload is far larger than an empty wheel (~6 KB),
+     guarding against the "dist-info only" regression.
+  3. INSTALL — pip-installs the wheel into a throwaway venv, imports the
+     package, loads the apple_mail_mcp.__main__:main entry point, and confirms
+     the mcp-apple-mail console script resolves. (Skip with --skip-install.)
+
+Usage:
+    python scripts/verify_wheel.py                 # auto-find newest dist/*.whl
+    python scripts/verify_wheel.py path/to.whl     # explicit wheel
+    python scripts/verify_wheel.py --skip-install  # structure/size checks only
+
+Exits 0 on success, non-zero (with a clear message) on any failure.
+stdlib-only — safe to run in CI before any dependency install.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+import venv
+import zipfile
+from pathlib import Path
+
+PACKAGE = "apple_mail_mcp"
+DIST_NAME = "mcp-apple-mail"
+CONSOLE_SCRIPT = "mcp-apple-mail"
+ENTRY_POINT = "apple_mail_mcp.__main__:main"
+
+# An empty/broken wheel (dist-info only) is ~6 KB. A healthy build is >200 KB.
+MIN_PACKAGE_BYTES = 50_000
+MIN_PACKAGE_FILES = 8
+
+
+def fail(msg: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"FAIL — {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def find_wheel(explicit: str | None) -> Path:
+    if explicit:
+        p = Path(explicit)
+        if not p.is_file():
+            fail(f"wheel not found: {p}")
+        return p
+    dist = Path("dist")
+    if not dist.is_dir():
+        fail("no dist/ directory — run `python -m build` first (or pass a wheel path)")
+    wheels = sorted(dist.glob("*.whl"), key=lambda p: p.stat().st_mtime)
+    if not wheels:
+        fail("no *.whl found in dist/ — run `python -m build` first")
+    return wheels[-1]
+
+
+def check_structure(wheel: Path) -> None:
+    print(f"==> Inspecting {wheel.name}")
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+        infos = {i.filename: i.file_size for i in zf.infolist()}
+
+    pkg_files = [n for n in names if n.startswith(f"{PACKAGE}/") and n.endswith(".py")]
+    required = {f"{PACKAGE}/__init__.py", f"{PACKAGE}/__main__.py"}
+    missing = sorted(r for r in required if r not in names)
+    if missing:
+        fail(
+            f"wheel is missing required module file(s): {', '.join(missing)}. "
+            f"This is the 2.2.0-style 'package not included' regression. "
+            f"Check [tool.hatch.build.targets.wheel] packages in pyproject.toml."
+        )
+
+    if len(pkg_files) < MIN_PACKAGE_FILES:
+        fail(
+            f"wheel contains only {len(pkg_files)} {PACKAGE}/*.py files "
+            f"(expected >= {MIN_PACKAGE_FILES}). Payload looks incomplete."
+        )
+
+    pkg_bytes = sum(sz for n, sz in infos.items() if n.startswith(f"{PACKAGE}/"))
+    if pkg_bytes < MIN_PACKAGE_BYTES:
+        fail(
+            f"{PACKAGE}/ payload is only {pkg_bytes} bytes "
+            f"(expected >= {MIN_PACKAGE_BYTES}). Likely a dist-info-only wheel."
+        )
+
+    print(f"    OK structure: {len(pkg_files)} module files, {pkg_bytes:,} bytes in {PACKAGE}/")
+
+
+def check_install(wheel: Path) -> None:
+    print("==> Clean-venv install + import + entry-point check")
+    with tempfile.TemporaryDirectory() as td:
+        venv_dir = Path(td) / "venv"
+        venv.create(venv_dir, with_pip=True, clear=True)
+        bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+        py = bin_dir / ("python.exe" if sys.platform == "win32" else "python")
+        pip = bin_dir / ("pip.exe" if sys.platform == "win32" else "pip")
+
+        res = subprocess.run(
+            [str(pip), "install", "--quiet", str(wheel)],
+            capture_output=True, text=True,
+        )
+        if res.returncode != 0:
+            fail(f"pip install of the wheel failed:\n{res.stdout}\n{res.stderr}")
+
+        probe = (
+            "import importlib, importlib.metadata as md\n"
+            "import apple_mail_mcp\n"
+            "from apple_mail_mcp.__main__ import main\n"
+            "for mod in ('core','tools.compose','tools.search','tools.manage',"
+            "'tools.inbox','tools.analytics','tools.smart_inbox'):\n"
+            "    importlib.import_module('apple_mail_mcp.' + mod)\n"
+            "eps = [e for e in md.entry_points(group='console_scripts') "
+            f"if e.name == {CONSOLE_SCRIPT!r}]\n"
+            "assert eps, 'console script entry point missing'\n"
+            f"assert eps[0].value == {ENTRY_POINT!r}, 'entry point target changed: ' + eps[0].value\n"
+            "assert callable(eps[0].load()), 'entry point does not load to a callable'\n"
+            "print(apple_mail_mcp.__version__)\n"
+        )
+        res = subprocess.run([str(py), "-c", probe], capture_output=True, text=True)
+        if res.returncode != 0:
+            fail(f"smoke import / entry-point check failed:\n{res.stdout}\n{res.stderr}")
+
+        installed_version = res.stdout.strip().splitlines()[-1]
+
+        # The console script must exist on the venv PATH and be runnable.
+        script = bin_dir / (f"{CONSOLE_SCRIPT}.exe" if sys.platform == "win32" else CONSOLE_SCRIPT)
+        if not script.exists():
+            fail(f"console script not installed: {script}")
+
+    print(f"    OK install: imported apple_mail_mcp {installed_version}, "
+          f"entry point {ENTRY_POINT} resolves, `{CONSOLE_SCRIPT}` script present")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Verify a built wheel before publishing.")
+    ap.add_argument("wheel", nargs="?", help="path to wheel (default: newest dist/*.whl)")
+    ap.add_argument("--skip-install", action="store_true",
+                    help="skip the clean-venv install test (structure/size only)")
+    args = ap.parse_args()
+
+    wheel = find_wheel(args.wheel)
+    check_structure(wheel)
+    if args.skip_install:
+        print("==> Skipping clean-venv install (--skip-install)")
+    else:
+        check_install(wheel)
+
+    print(f"\nPASS — {wheel.name} is a healthy {DIST_NAME} distribution.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/patrickfreyer/apple-mail-mcp",
     "source": "github"
   },
-  "version": "3.1.6",
+  "version": "3.1.7",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-apple-mail",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## What this fixes

`uvx mcp-apple-mail` still installs the **broken 2.2.0** wheel today — it ships only `dist-info` + the console script, not the `apple_mail_mcp/` package, so it crashes with `ModuleNotFoundError: No module named 'apple_mail_mcp'` (issues #42, #57).

**Root cause turned out to be a release-process gap, not a packaging-config bug.** The config was already fixed in the 3.1.x line, but **v3.0.0–v3.1.6 were only git-tagged, never uploaded to PyPI** — so PyPI stayed on the broken 2.2.0 for months. (Verified: PyPI's `mcp-apple-mail` index lists only 2.2.0 files; a local 3.1.6 build is healthy and installs cleanly.)

## What's in this PR

- **`scripts/verify_wheel.py`** — pre-publish artifact guard. Checks the wheel contains the `apple_mail_mcp/` package + a sane payload size, then does a clean-venv install + import + entry-point check. Verified it **fails closed** on a synthesized 2.2.0-style wheel.
- **`.github/workflows/ci.yml`** — every push/PR builds the wheel, runs `verify_wheel.py`, and runs the 82-test suite on Python 3.10–3.13.
- **`.github/workflows/release.yml`** — on a `vX.Y.Z` tag: build + verify, then publish to PyPI via **Trusted Publishing (OIDC, no stored tokens)**. Fails closed if the tag ≠ pyproject version.
- **`CHANGELOG.md`** (pyproject linked to a missing file) + **`RELEASING.md`** (release flow + one-time PyPI setup).
- **Version bump 3.1.6 → 3.1.7** across all tracked files (drift guard passes).
- **README**: de-versioned the `.mcpb` download link so it stops going stale.

## On issue #57

The README's `uvx mcp-apple-mail` name is **correct** — `mcp-apple-mail` is this project's PyPI distribution (author: Patrick Freyer). `apple-mail-mcp` on PyPI is an **unrelated package by a different author** (imdinu), so #57's suggested rename would point users at the wrong package. The real reason `uvx` "fails" is the stale 2.2.0 — fixed by publishing 3.1.7. #57's docs change is therefore **not** applied.

## Action items to actually ship (maintainer)

1. **One-time PyPI setup** — add the GitHub trusted publisher (owner `patrickfreyer`, repo `apple-mail-mcp`, workflow `release.yml`, environment `pypi`). Steps in `RELEASING.md`.
2. Merge this PR.
3. `git tag v3.1.7 && git push origin v3.1.7` → the Release workflow builds, verifies, and publishes to PyPI automatically.

Fixes #42. Addresses #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
