### PR TITLE
ci: auto-build and attach the .mcpb bundle to each GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,46 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Build .mcpb + attach to GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release + upload the .mcpb asset
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build the .mcpb bundle
+        run: bash apple-mail-mcpb/build-mcpb.sh
+
+      # Same "don't ship a broken artifact" guard as the wheel: the bundle must
+      # contain the apple_mail_mcp package and must not leak venv/ or pycache.
+      - name: Verify the .mcpb contains the apple_mail_mcp package
+        run: |
+          MCPB=$(ls apple-mail-mcp-v*.mcpb)
+          echo "bundle: $MCPB"
+          for f in apple_mail_mcp/__init__.py apple_mail_mcp/__main__.py; do
+            if ! unzip -l "$MCPB" | grep -q "$f"; then
+              echo "::error::$MCPB is missing $f"; exit 1
+            fi
+          done
+          if unzip -l "$MCPB" | grep -qE '/venv/|__pycache__'; then
+            echo "::error::$MCPB leaked venv/ or __pycache__"; exit 1
+          fi
+
+      - name: Build release notes from CHANGELOG
+        run: python scripts/extract_changelog.py > RELEASE_BODY.md
+
+      - name: Create / update the GitHub Release with the bundle
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: RELEASE_BODY.md
+          generate_release_notes: true
+          files: apple-mail-mcp-v*.mcpb
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to **mcp-apple-mail** are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Release workflow now builds and attaches the `.mcpb` bundle** to the GitHub
+  Release automatically on each tag (verifies the bundle contains the
+  `apple_mail_mcp` package and doesn't leak `venv/`/`__pycache__`).
+- **`scripts/extract_changelog.py`** — pulls the current version's section from
+  this file to use as the GitHub Release body.
+
 ## [3.1.7] - 2026-06-12
 
 First 3.x release actually published to PyPI. Versions 3.0.0–3.1.6 were tagged

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,10 +50,17 @@ publisher:
    git tag v3.1.7
    git push origin v3.1.7
    ```
-5. The **Release** workflow runs automatically: it checks the tag matches the
-   version, builds, runs `verify_wheel.py`, and publishes to PyPI.
+5. The **Release** workflow runs automatically and does three things:
+   - checks the tag matches the version, builds, runs `verify_wheel.py`, and
+     **publishes to PyPI**;
+   - builds the **`.mcpb` bundle** (`apple-mail-mcpb/build-mcpb.sh`), verifies it
+     contains the `apple_mail_mcp` package, and **creates the GitHub Release with
+     the bundle attached** (notes pulled from `CHANGELOG.md` via
+     `scripts/extract_changelog.py`).
 6. Confirm: `uvx mcp-apple-mail` (or `pip install -U mcp-apple-mail`) pulls the
-   new version and starts cleanly.
+   new version and starts cleanly, and the GitHub Release has the `.mcpb` asset.
+
+> No manual `.mcpb` build or release upload is needed — the tag drives all of it.
 
 ## Verifying a build locally (before tagging)
 

--- a/scripts/extract_changelog.py
+++ b/scripts/extract_changelog.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+extract_changelog.py — Print the CHANGELOG section for the current version.
+
+Reads the version from pyproject.toml, finds the matching `## [<version>]`
+heading in CHANGELOG.md, and prints that section (up to the next `## ` heading).
+Used by the release workflow to build GitHub Release notes from the changelog.
+
+Usage:
+    python scripts/extract_changelog.py            # current pyproject version
+    python scripts/extract_changelog.py 3.1.7      # explicit version
+
+Always exits 0. If no matching section is found, prints a short fallback so a
+release never fails just because the changelog wasn't updated.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def current_version() -> str:
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    return data["project"]["version"]
+
+
+def extract(version: str) -> str | None:
+    changelog = REPO_ROOT / "CHANGELOG.md"
+    if not changelog.is_file():
+        return None
+    lines = changelog.read_text().splitlines()
+
+    # Match e.g. "## [3.1.7] - 2026-06-12" (tolerate any trailing text).
+    start = None
+    head_re = re.compile(r"^##\s+\[" + re.escape(version) + r"\]")
+    for i, line in enumerate(lines):
+        if head_re.match(line):
+            start = i
+            break
+    if start is None:
+        return None
+
+    body: list[str] = []
+    for line in lines[start + 1:]:
+        if line.startswith("## "):  # next section heading
+            break
+        body.append(line)
+
+    text = "\n".join(body).strip("\n")
+    return text or None
+
+
+def main() -> None:
+    version = sys.argv[1] if len(sys.argv) > 1 else current_version()
+    section = extract(version)
+    if section:
+        print(section)
+    else:
+        print(f"Release {version}. See CHANGELOG.md for details.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this does

Makes a single tag drive the **entire** release. Today `release.yml` publishes to PyPI on a tag; this adds the `.mcpb` Claude Desktop bundle to the same flow so it's built and attached to the GitHub Release automatically — no manual `build-mcpb.sh` + upload step (which is how v3.1.7's bundle had to be done by hand).

## Changes

- **`release.yml`** — new `github-release` job (`needs: build`, tags only):
  1. runs `apple-mail-mcpb/build-mcpb.sh`
  2. **guards the bundle** — fails if it's missing the `apple_mail_mcp` package or leaks `venv/`/`__pycache__` (same "don't ship a broken artifact" discipline as the wheel guard)
  3. creates/updates the GitHub Release via `softprops/action-gh-release@v2` with the `.mcpb` attached, notes from the CHANGELOG
- **`scripts/extract_changelog.py`** — pulls the current version's section from `CHANGELOG.md` for the release body (safe fallback if absent)
- **`CHANGELOG.md`** — `Unreleased` section; **`RELEASING.md`** — documents the now-automated bundle

## Result

After merge, the next `git tag vX.Y.Z && git push origin vX.Y.Z` produces: the PyPI publish **and** a GitHub Release with the `.mcpb` attached, with zero manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
