### PR TITLE
feat: surface message_id + mail_link in list_inbox_emails (parity with search)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`list_inbox_emails` now surfaces `message_id`, `internet_message_id` and a
+  `mail_link`** in both its JSON and text output, matching `search_emails` (and the
+  text deep link added for search in #44) — inbox listings can be cited as Apple
+  Mail deep links (`message://…`) and targeted by id without a second lookup.
+  Backward-compatible with older 5-field records.
 - **Release workflow now builds and attaches the `.mcpb` bundle** to the GitHub
   Release automatically on each tag (verifies the bundle contains the
   `apple_mail_mcp` package and doesn't leak `venv/`/`__pycache__`).

--- a/plugin/apple_mail_mcp/tools/inbox.py
+++ b/plugin/apple_mail_mcp/tools/inbox.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Optional, List, Dict, Any
+from urllib.parse import quote
 
 from apple_mail_mcp.server import mcp
 from apple_mail_mcp.core import (
@@ -23,15 +24,24 @@ def _parse_pipe_delimited_emails(raw: str) -> List[Dict[str, Any]]:
             continue
         parts = line.split("|||")
         if len(parts) >= 5:
-            emails.append(
-                {
-                    "subject": parts[0].strip(),
-                    "sender": parts[1].strip(),
-                    "date": parts[2].strip(),
-                    "is_read": parts[3].strip().lower() == "true",
-                    "account": parts[4].strip(),
-                }
-            )
+            email: Dict[str, Any] = {
+                "subject": parts[0].strip(),
+                "sender": parts[1].strip(),
+                "date": parts[2].strip(),
+                "is_read": parts[3].strip().lower() == "true",
+                "account": parts[4].strip(),
+            }
+            # Trailing identity fields mirror search_emails: the internal Mail id
+            # (precise targeting) and the RFC Message-ID (citation / deep link).
+            if len(parts) >= 6 and parts[5].strip():
+                email["message_id"] = parts[5].strip()
+            if len(parts) >= 7:
+                internet_message_id = parts[6].strip()
+                if internet_message_id:
+                    email["internet_message_id"] = internet_message_id
+                    msg_id = internet_message_id.strip("<>")
+                    email["mail_link"] = f"message://%3C{quote(msg_id, safe='@')}%3E"
+            emails.append(email)
     return emails
 
 
@@ -93,6 +103,10 @@ def list_inbox_emails(
                             set messageSender to sender of aMessage
                             set messageDate to date received of aMessage
                             set messageRead to read status of aMessage
+                            set messageInternetId to ""
+                            try
+                                set messageInternetId to message id of aMessage
+                            end try
 
                             set shouldInclude to true
                             if not {str(include_read).lower()} and messageRead then
@@ -109,6 +123,12 @@ def list_inbox_emails(
                                 set outputText to outputText & readIndicator & " " & messageSubject & return
                                 set outputText to outputText & "   From: " & messageSender & return
                                 set outputText to outputText & "   Date: " & (messageDate as string) & return
+                                if messageInternetId is not "" then
+                                    set cleanMid to messageInternetId
+                                    if cleanMid starts with "<" then set cleanMid to text 2 thru -1 of cleanMid
+                                    if cleanMid ends with ">" then set cleanMid to text 1 thru -2 of cleanMid
+                                    set outputText to outputText & "   Link: message://%3C" & cleanMid & "%3E" & return
+                                end if
 
                                 {content_preview_script(200) if include_content else ""}
 
@@ -167,12 +187,17 @@ def _list_inbox_emails_json(
                         set messageSender to sender of aMessage
                         set messageDate to date received of aMessage
                         set messageRead to read status of aMessage
+                        set messageInternalId to (id of aMessage) as string
+                        set messageInternetId to ""
+                        try
+                            set messageInternetId to message id of aMessage
+                        end try
                         set shouldInclude to true
                         if not {str(include_read).lower()} and messageRead then
                             set shouldInclude to false
                         end if
                         if shouldInclude then
-                            set end of resultLines to messageSubject & "|||" & messageSender & "|||" & (messageDate as string) & "|||" & messageRead & "|||" & accountName
+                            set end of resultLines to messageSubject & "|||" & messageSender & "|||" & (messageDate as string) & "|||" & messageRead & "|||" & accountName & "|||" & messageInternalId & "|||" & messageInternetId
                         end if
                     end try
                 end repeat

--- a/tests/test_inbox_tools.py
+++ b/tests/test_inbox_tools.py
@@ -1,0 +1,111 @@
+"""Tests for inbox listing — identity-field parity with search_emails."""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from apple_mail_mcp.tools import inbox as inbox_tools
+
+
+def _inbox_record(
+    subject,
+    sender="sender@example.com",
+    date="2026-03-07T10:00:00",
+    is_read=False,
+    account="Work",
+    message_id="123",
+    internet_message_id="<abc@example.com>",
+):
+    return "|||".join(
+        [
+            subject,
+            sender,
+            date,
+            "true" if is_read else "false",
+            account,
+            message_id,
+            internet_message_id,
+        ]
+    )
+
+
+class ListInboxIdentityTests(unittest.TestCase):
+    def test_list_inbox_json_surfaces_message_id_and_mail_link(self):
+        def fake_run(script, timeout=120):
+            return _inbox_record(
+                "Quarterly report",
+                message_id="456",
+                internet_message_id="<QwcH6OP9REaEX0pi8aR6-g@geopod-ismtpd-60>",
+            )
+
+        with patch("apple_mail_mcp.tools.inbox.run_applescript", side_effect=fake_run):
+            items = json.loads(inbox_tools.list_inbox_emails(output_format="json"))
+
+        self.assertEqual(len(items), 1)
+        item = items[0]
+        self.assertEqual(item["message_id"], "456")
+        self.assertEqual(
+            item["internet_message_id"], "<QwcH6OP9REaEX0pi8aR6-g@geopod-ismtpd-60>"
+        )
+        self.assertEqual(
+            item["mail_link"],
+            "message://%3CQwcH6OP9REaEX0pi8aR6-g@geopod-ismtpd-60%3E",
+        )
+
+    def test_list_inbox_json_mail_link_normalizes_missing_angle_brackets(self):
+        """AppleScript returns the Message-ID without angle brackets; the
+        mail_link should still wrap it (percent-encoded), like search_emails."""
+
+        def fake_run(script, timeout=120):
+            return _inbox_record("Unbracketed", internet_message_id="abc@example.com")
+
+        with patch("apple_mail_mcp.tools.inbox.run_applescript", side_effect=fake_run):
+            items = json.loads(inbox_tools.list_inbox_emails(output_format="json"))
+
+        self.assertEqual(items[0]["internet_message_id"], "abc@example.com")
+        self.assertEqual(items[0]["mail_link"], "message://%3Cabc@example.com%3E")
+
+    def test_list_inbox_json_tolerates_legacy_records_without_identity(self):
+        """A 5-field record (pre-identity format) must still parse cleanly."""
+
+        def fake_run(script, timeout=120):
+            return "Subject|||sender@example.com|||2026-03-07T10:00:00|||false|||Work"
+
+        with patch("apple_mail_mcp.tools.inbox.run_applescript", side_effect=fake_run):
+            items = json.loads(inbox_tools.list_inbox_emails(output_format="json"))
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["subject"], "Subject")
+        self.assertNotIn("message_id", items[0])
+        self.assertNotIn("mail_link", items[0])
+
+    def test_list_inbox_json_script_reads_both_ids(self):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return ""
+
+        with patch("apple_mail_mcp.tools.inbox.run_applescript", side_effect=fake_run):
+            inbox_tools.list_inbox_emails(output_format="json")
+
+        self.assertIn("id of aMessage", captured["script"])
+        self.assertIn("message id of aMessage", captured["script"])
+
+    def test_list_inbox_text_script_builds_mail_link(self):
+        """Text output surfaces the message:// deep link too (mirrors #44)."""
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return "INBOX EMAILS - ALL ACCOUNTS"
+
+        with patch("apple_mail_mcp.tools.inbox.run_applescript", side_effect=fake_run):
+            inbox_tools.list_inbox_emails(output_format="text")
+
+        self.assertIn("message id of aMessage", captured["script"])
+        self.assertIn('"   Link: message://%3C"', captured["script"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #75.

Completes the id-first surface (#34/#44/#50): `list_inbox_emails` now returns the same identity fields `search_emails` already does, so inbox listings can be opened as deep links and fed straight to `move_email` / `reply_to_email_by_id` without a second lookup.

### Changes
- **JSON + text output** now include `message_id`, `internet_message_id`, and `mail_link`. The text deep link mirrors what #44 added for search.
- AppleScript reads `id of aMessage` + try-guarded `message id of aMessage`; the JSON parser reuses `search_emails`' normalization (`strip("<>")`, `quote(…, safe="@")`).
- **Backward-compatible**: 5-field records still parse (no new keys emitted).

### Notes
- `message_id` is Mail's internal id — stable within a session for targeting (as `move_email` uses it); `internet_message_id` is the durable RFC id for citations. Same semantics as `search_emails`.
- The two appended id fields aren't routed through `sanitize_field` (unlike search's): both are delimiter-safe by construction (numeric id; unfolded RFC Message-ID has no `|||`/newline). Happy to wrap them if you'd prefer strict consistency.

### Tests
`tests/test_inbox_tools.py` (5): ids + mail_link surfaced, bracket normalization, legacy 5-field tolerance, JSON + text scripts build the link. Full suite green (101). CHANGELOG updated.
