### PR TITLE
Fix stored XSS in inbox dashboard (script-context breakout + innerHTML sinks)

### DIFF
--- a/plugin/ui/dashboard.py
+++ b/plugin/ui/dashboard.py
@@ -12,6 +12,26 @@ from typing import Dict, List, Any
 from mcp_ui_server import create_ui_resource
 
 
+def _json_for_script(obj: Any) -> str:
+    """Serialize ``obj`` to JSON safe to embed inside an HTML ``<script>`` block.
+
+    json.dumps does not escape '<', '>', '&' or the JS line separators
+    U+2028/U+2029. Inside a <script> element, a value containing "</script>"
+    (e.g. an attacker-controlled email subject or sender) would close the
+    script element early and inject arbitrary HTML -- a stored XSS. Escaping
+    these as \\uXXXX keeps the output valid JSON that parses to the identical
+    value, but it can no longer break out of the script context.
+    """
+    return (
+        json.dumps(obj, ensure_ascii=False)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
 def create_inbox_dashboard_ui(
     accounts_data: Dict[str, int],
     recent_emails: List[Dict[str, Any]]
@@ -41,8 +61,11 @@ def create_inbox_dashboard_ui(
         template_content = f.read()
 
     # Serialize the data for injection into the template
-    accounts_json = json.dumps(accounts_data, ensure_ascii=False)
-    emails_json = json.dumps(recent_emails, ensure_ascii=False)
+    # Escaped for the HTML <script> context (see _json_for_script): email
+    # subjects/senders are attacker-controlled and could otherwise break out
+    # via "</script>" and inject HTML (stored XSS).
+    accounts_json = _json_for_script(accounts_data)
+    emails_json = _json_for_script(recent_emails)
 
     # Inject data into the template
     html_content = template_content.replace(

--- a/plugin/ui/templates/dashboard.html
+++ b/plugin/ui/templates/dashboard.html
@@ -633,13 +633,13 @@
                 card.setAttribute('data-account', name);
                 card.innerHTML = `
                     <div class="account-avatar" style="background: ${color}">
-                        ${initials}
+                        ${escapeHtml(initials)}
                     </div>
                     <div class="account-info">
                         <div class="account-name">${escapeHtml(name)}</div>
                         <div class="account-status">${unreadCount > 0 ? 'Active' : 'All caught up'}</div>
                     </div>
-                    <div class="unread-badge ${unreadCount === 0 ? 'zero' : ''}">${unreadCount}</div>
+                    <div class="unread-badge ${unreadCount === 0 ? 'zero' : ''}">${escapeHtml(String(unreadCount))}</div>
                 `;
 
                 card.addEventListener('click', () => filterByAccount(name));


### PR DESCRIPTION
### Problem

The inbox dashboard renders email data into HTML in two unsafe ways:

1. **Script-context breakout (primary, attacker-controlled).**
   `create_inbox_dashboard_ui()` serializes email data with `json.dumps(...)`
   and substitutes it into a `<script>` block. `json.dumps` does not escape
   `<`, `>`, `&`, or the JS line separators U+2028/U+2029, so a value
   containing `</script>` closes the script element early and the remainder is
   parsed as HTML — a stored XSS. The injected values include email
   **subjects and senders**, which are attacker-controlled (anyone who emails
   the user can plant markup in a subject line). The payload executes when the
   dashboard is rendered in an MCP-UI-capable client.

2. **Unescaped `innerHTML` sinks (defense-in-depth).** In the account card,
   `${initials}` (derived from the account name) and `${unreadCount}` were
   interpolated into `innerHTML` without escaping. Lower severity (initials is
   capped at 2 chars; account names are user-configured), but still unescaped.

### Fix

1. Add `_json_for_script()` — after `json.dumps`, escape `<`, `>`, `&`,
   U+2028, U+2029 as `\uXXXX`. This is the standard "JSON in a `<script>`"
   hardening (same approach as Django's `json_script`). The output remains
   valid JSON that parses to the identical value, so the dashboard renders the
   same data — it simply can no longer break out of the script element.
2. Wrap the two remaining sinks in the existing `escapeHtml()`.

### Testing

- A subject of `</script><img src=x onerror=...>` now serializes with the
  `<` escaped to `<`, so it cannot close the script tag.
- U+2028/U+2029 in a body are escaped; `json.loads()` of the output
  round-trips to the original object (no data change).
- `py_compile` passes; `dashboard.py` is ASCII-only.

---

_This fix was written by Claude (Opus 4.8) and reviewed with OpenAI Codex
before submission._
