### PR TITLE
Fix UTF-8 handling for non-ASCII text in pasteboard email bodies

### DIFF
--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -208,6 +208,23 @@ else
 end if"""
 
 
+def _plain_text_to_pasteboard_script(
+    text_temp_path, pb_var="pb", old_clip_var="oldClip"
+):
+    """Return an AppleScriptObjC snippet that places UTF-8 text on the pasteboard."""
+    return f"""set textNSStr to current application's NSString's stringWithContentsOfFile:"{text_temp_path}" encoding:(current application's NSUTF8StringEncoding) |error|:(missing value)
+set {pb_var} to current application's NSPasteboard's generalPasteboard()
+set {old_clip_var} to {pb_var}'s stringForType:(current application's NSPasteboardTypeString)
+{pb_var}'s clearContents()
+if textNSStr is not missing value then
+    set gapNSStr to current application's NSString's stringWithString:(return & return)
+    set pasteText to textNSStr's stringByAppendingString:gapNSStr
+    {pb_var}'s setString:pasteText forType:(current application's NSPasteboardTypeString)
+else
+    {pb_var}'s setString:"" forType:(current application's NSPasteboardTypeString)
+end if"""
+
+
 def _prepare_rich_bodies(subject, text_body, html_body):
     """Return plain-text and HTML bodies, filling sensible placeholders."""
     plain_body = text_body or ""
@@ -702,30 +719,25 @@ def reply_to_email(
     body_tmp.close()
     body_temp_path = body_tmp.name
 
-    # If body_html provided, write it to a temp file for the AppleScript to read.
-    # If plain text only, wrap it in basic HTML so the clipboard paste renders
-    # properly in Mail's HTML compose view (preserving line breaks and gap).
+    # If body_html is provided, write it to a temp file for the AppleScript to
+    # read as rich text. Plain text replies use the text pasteboard directly so
+    # Mail keeps its normal reply formatting above the quoted original.
     html_temp_path = None
     # Append an empty paragraph to create a visible gap before the quoted original.
     # Mail strips trailing <br> tags, so we use a <p> with &nbsp; instead.
     gap_html = "<div><br></div><div><br></div>"
     if body_html:
         html_content = body_html + gap_html
-    else:
-        # Wrap plain text in HTML, converting newlines to <br>
-        escaped_plain = html_escape(reply_body)
-        escaped_plain = escaped_plain.replace("\n", "<br>")
-        html_content = f"<div>{escaped_plain}</div>{gap_html}"
-    html_tmp = tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".html",
-        prefix="mail_reply_html_",
-        delete=False,
-        encoding="utf-8",
-    )
-    html_tmp.write(_html_with_ascii_entities(html_content))
-    html_tmp.close()
-    html_temp_path = html_tmp.name
+        html_tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".html",
+            prefix="mail_reply_html_",
+            delete=False,
+            encoding="utf-8",
+        )
+        html_tmp.write(_html_with_ascii_entities(html_content))
+        html_tmp.close()
+        html_temp_path = html_tmp.name
 
     # Build the reply command based on reply_to_all flag
     if reply_to_all:
@@ -787,7 +799,8 @@ def reply_to_email(
     read_body_script = f'set replyBodyText to do shell script "cat " & quoted form of "{body_temp_path}"'
 
     # Determine behavior per mode
-    # All modes use HTML clipboard paste (via NSPasteboard) to insert the reply body.
+    # All modes use clipboard paste to insert the reply body. HTML replies use
+    # RTF via NSPasteboard; plain text replies use NSPasteboardTypeString.
     # This preserves Mail.app's native quoted original in the HTML layer.
     # (setting `content` via AppleScript overwrites the HTML layer entirely,
     # destroying the email thread history.)
@@ -814,7 +827,15 @@ def reply_to_email(
         success_text = "Reply saved as draft!"
 
     cleanup_script = f'do shell script "rm -f " & quoted form of "{body_temp_path}"'
-    html_cleanup_script = f'do shell script "rm -f \'{html_temp_path}\'"'
+    html_cleanup_script = (
+        f'do shell script "rm -f \'{html_temp_path}\'"' if html_temp_path else ""
+    )
+
+    pasteboard_script = (
+        _html_to_pasteboard_script(html_temp_path)
+        if body_html
+        else _plain_text_to_pasteboard_script(body_temp_path)
+    )
 
     sender_script = _compose_sender_script(
         "replyMessage", "targetAccount", sender_override
@@ -825,10 +846,8 @@ use framework "Foundation"
 use framework "AppKit"
 use scripting additions
 
--- Step 1: Place the reply body on the clipboard as RTF (rendered rich text)
--- plus a plain-text fallback. The previous raw-HTML-source approach made
--- Mail paste the body twice (rendered + literal tags); RTF pastes once.
-{_html_to_pasteboard_script(html_temp_path)}
+-- Step 1: Place the reply body on the clipboard.
+{pasteboard_script}
 
 -- Step 2: Find the email and create reply
 tell application "Mail"
@@ -877,7 +896,7 @@ tell application "Mail"
                 {attachment_script}
             end tell
 
-            -- Paste reply body (HTML already on clipboard from Step 1).
+            -- Paste reply body (already on clipboard from Step 1).
             -- The body is inserted via a blind Cmd+V into the compose window, so the
             -- window MUST have keyboard focus when the keystroke fires. If Mail is not
             -- frontmost at that moment (common on the first compose of a session, when

--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -152,12 +152,18 @@ def _build_html_from_text(text_body):
     """Return a simple HTML wrapper for plain text content."""
     safe_body = html_escape(text_body or "")
     return (
-        '<html><body style="font-family: -apple-system, BlinkMacSystemFont, '
+        '<html><head><meta charset="utf-8"></head>'
+        '<body style="font-family: -apple-system, BlinkMacSystemFont, '
         "'Segoe UI', Arial, sans-serif; line-height: 1.45; color: #111111;\">"
         '<pre style="white-space: pre-wrap; font: inherit; margin: 0;">'
         + safe_body
         + "</pre></body></html>"
     )
+
+
+def _html_with_ascii_entities(html_content):
+    """Return HTML with non-ASCII characters encoded as character references."""
+    return (html_content or "").encode("ascii", "xmlcharrefreplace").decode("ascii")
 
 
 def _html_to_pasteboard_script(html_temp_path, pb_var="pb", old_clip_var="oldClip"):
@@ -185,7 +191,9 @@ set {pb_var} to current application's NSPasteboard's generalPasteboard()
 set {old_clip_var} to {pb_var}'s stringForType:(current application's NSPasteboardTypeString)
 set htmlNSStr to current application's NSString's stringWithString:htmlString
 set htmlBytes to htmlNSStr's dataUsingEncoding:(current application's NSUTF8StringEncoding)
-set htmlOpts to current application's NSDictionary's dictionaryWithObject:(current application's NSHTMLTextDocumentType) forKey:(current application's NSDocumentTypeDocumentAttribute)
+set htmlOpts to current application's NSMutableDictionary's dictionary()
+htmlOpts's setObject:(current application's NSHTMLTextDocumentType) forKey:(current application's NSDocumentTypeDocumentAttribute)
+htmlOpts's setObject:(current application's NSNumber's numberWithUnsignedInteger:(current application's NSUTF8StringEncoding)) forKey:(current application's NSCharacterEncodingDocumentAttribute)
 set attrStr to current application's NSAttributedString's alloc()'s initWithData:htmlBytes options:htmlOpts documentAttributes:(missing value) |error|:(missing value)
 {pb_var}'s clearContents()
 if attrStr is not missing value then
@@ -447,7 +455,7 @@ def _send_html_email(
         delete=False,
         encoding="utf-8",
     )
-    tmp.write(body_html)
+    tmp.write(_html_with_ascii_entities(body_html))
     tmp.close()
     html_temp_path = tmp.name
 
@@ -715,7 +723,7 @@ def reply_to_email(
         delete=False,
         encoding="utf-8",
     )
-    html_tmp.write(html_content)
+    html_tmp.write(_html_with_ascii_entities(html_content))
     html_tmp.close()
     html_temp_path = html_tmp.name
 
@@ -1269,7 +1277,7 @@ def forward_email(
             delete=False,
             encoding="utf-8",
         )
-        fwd_html_tmp.write(fwd_html_content)
+        fwd_html_tmp.write(_html_with_ascii_entities(fwd_html_content))
         fwd_html_tmp.close()
         fwd_html_temp_path = fwd_html_tmp.name
         fwd_html_cleanup_script = f'do shell script "rm -f \'{fwd_html_temp_path}\'"'

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -18,6 +18,22 @@ def _make_subprocess_result(returncode=0, stdout=b"", stderr=b""):
 
 
 class ComposeToolTests(unittest.TestCase):
+    def test_html_with_ascii_entities_preserves_unicode_as_entities(self):
+        html = "<p>Bestätigungen, Passwörter, Grüße</p>"
+
+        result = compose_tools._html_with_ascii_entities(html)
+
+        self.assertEqual(
+            result,
+            "<p>Best&#228;tigungen, Passw&#246;rter, Gr&#252;&#223;e</p>",
+        )
+
+    def test_pasteboard_html_import_declares_utf8_encoding(self):
+        script = compose_tools._html_to_pasteboard_script("/tmp/body.html")
+
+        self.assertIn("NSCharacterEncodingDocumentAttribute", script)
+        self.assertIn("NSUTF8StringEncoding", script)
+
     def test_create_rich_email_draft_writes_multipart_eml(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "weekly-update.eml"

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -34,6 +34,13 @@ class ComposeToolTests(unittest.TestCase):
         self.assertIn("NSCharacterEncodingDocumentAttribute", script)
         self.assertIn("NSUTF8StringEncoding", script)
 
+    def test_plain_text_pasteboard_uses_string_not_rtf(self):
+        script = compose_tools._plain_text_to_pasteboard_script("/tmp/body.txt")
+
+        self.assertIn("NSPasteboardTypeString", script)
+        self.assertIn("NSUTF8StringEncoding", script)
+        self.assertNotIn("NSPasteboardTypeRTF", script)
+
     def test_create_rich_email_draft_writes_multipart_eml(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "weekly-update.eml"


### PR DESCRIPTION
## Summary

- Preserve non-ASCII characters when pasteboard-based compose/reply/forward bodies are converted through `NSAttributedString`.
- Add an explicit UTF-8 HTML document encoding option for the AppKit HTML importer.
- Encode non-ASCII HTML characters as numeric character references before writing temporary pasteboard HTML files.

## Root Cause

Pasteboard-based replies and rich bodies write UTF-8 HTML to a temporary file and then import it through `NSAttributedString` before putting RTF on the pasteboard. Without an explicit character encoding, non-ASCII text such as German umlauts could be interpreted incorrectly by the HTML importer, producing mojibake in Mail replies.

Observed before this change:

```text
Bestätigungen -> BestÃ¤tigungen
McDonald’s -> McDonaldâ€™s
Grüße -> GrÃ¼ÃŸe
```

## Validation

- `uv run python -m unittest discover -s tests -p 'test_compose_tools.py'`
- Manual Apple Mail reply test with German text containing `ä`, `ö`, `ü`, `ß`, and `’`; the reply body rendered correctly and preserved the quoted thread history.
