### PR TITLE
fix: pin HTML->RTF importer to UTF-8 so umlauts/ß/emoji survive paste to Mail

### DIFF
--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -185,7 +185,13 @@ set {pb_var} to current application's NSPasteboard's generalPasteboard()
 set {old_clip_var} to {pb_var}'s stringForType:(current application's NSPasteboardTypeString)
 set htmlNSStr to current application's NSString's stringWithString:htmlString
 set htmlBytes to htmlNSStr's dataUsingEncoding:(current application's NSUTF8StringEncoding)
-set htmlOpts to current application's NSDictionary's dictionaryWithObject:(current application's NSHTMLTextDocumentType) forKey:(current application's NSDocumentTypeDocumentAttribute)
+-- Pin the HTML importer to UTF-8. Without NSCharacterEncodingDocumentAttribute the
+-- Cocoa HTML reader auto-detects the charset and defaults to Latin-1/Windows-1252,
+-- so the UTF-8 bytes for ä/ö/ü/ß/emoji get double-decoded into mojibake
+-- (e.g. "Grüße" -> "GrÃ¼ÃŸe"). Passing NSUTF8StringEncoding fixes all multibyte text.
+set htmlOptKeys to {{current application's NSDocumentTypeDocumentAttribute, current application's NSCharacterEncodingDocumentAttribute}}
+set htmlOptVals to {{current application's NSHTMLTextDocumentType, current application's NSUTF8StringEncoding}}
+set htmlOpts to current application's NSDictionary's dictionaryWithObjects:htmlOptVals forKeys:htmlOptKeys
 set attrStr to current application's NSAttributedString's alloc()'s initWithData:htmlBytes options:htmlOpts documentAttributes:(missing value) |error|:(missing value)
 {pb_var}'s clearContents()
 if attrStr is not missing value then

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -833,6 +833,11 @@ class HtmlBodyNoDuplicatePasteTests(unittest.TestCase):
         self.assertIn("NSPasteboardTypeRTF", script)
         self.assertIn("RTFFromRange", script)
         self.assertIn("NSAttributedString", script)
+        # The HTML importer must be pinned to UTF-8, otherwise Cocoa auto-detects
+        # the charset and defaults to Latin-1/Windows-1252, double-decoding the
+        # UTF-8 bytes for ä/ö/ü/ß/emoji into mojibake (e.g. "Grüße" -> "GrÃ¼ÃŸe").
+        self.assertIn("NSCharacterEncodingDocumentAttribute", script)
+        self.assertIn("NSUTF8StringEncoding", script)
 
     def test_reply_uses_rtf_not_raw_html(self):
         self._assert_rtf_not_raw_html(self._render_reply())
@@ -854,6 +859,24 @@ class HtmlBodyNoDuplicatePasteTests(unittest.TestCase):
         # (which would render as a second body under the pasted HTML).
         script = self._render_reply()
         self.assertNotIn(f'content:"{self.BODY_PLAIN}"', script)
+
+
+class PasteboardUtf8EncodingTests(unittest.TestCase):
+    """Guards the multibyte-UTF-8 fix in _html_to_pasteboard_script.
+
+    Regression: without NSCharacterEncodingDocumentAttribute -> NSUTF8StringEncoding,
+    the Cocoa HTML importer defaulted to Latin-1 and turned German umlauts/ß and
+    emoji into mojibake when relaying a body to Mail (reply/compose/forward).
+    """
+
+    def test_helper_pins_html_importer_to_utf8(self):
+        snippet = compose_tools._html_to_pasteboard_script("/tmp/example.html")
+        self.assertIn("NSCharacterEncodingDocumentAttribute", snippet)
+        self.assertIn("NSUTF8StringEncoding", snippet)
+        # Both the document-type and the encoding key must be in the options dict.
+        self.assertIn("NSDocumentTypeDocumentAttribute", snippet)
+        self.assertIn("NSHTMLTextDocumentType", snippet)
+        self.assertIn("dictionaryWithObjects:", snippet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
`reply_to_email` (and the other rich-relay tools) garbled multibyte UTF-8 — German umlauts (ä/ö/ü/ß), emoji, smart quotes — when relaying the body into Mail.app, even via plain `reply_body`. `Grüße` rendered as `GrÃ¼ÃŸe`.

## Root cause
The shared `_html_to_pasteboard_script` helper built the `NSAttributedString` with `NSHTMLTextDocumentType` but **never set `NSCharacterEncodingDocumentAttribute`**. With no charset specified, Cocoa's HTML importer defaults to Latin-1/Windows-1252, double-decoding the UTF-8 bytes into mojibake before the RTF is placed on the clipboard and pasted into Mail.

## Fix
Set the importer encoding to `NSUTF8StringEncoding`. Because this is the single shared bridge, the fix covers `reply_to_email` (send/draft/open), `compose_email` (HTML path), `forward_email` (note), and `create_rich_email_draft`.

Plain-text / subject / recipient paths were verified unaffected (they round-trip over UTF-8 osascript stdin correctly).

## Verification
- Before/after clipboard byte-match on `Grüße über größere Häppchen — ßẞ "Zitat" 😀` (plain + RTF flavors).
- Test suite: 102 passed (added 2 regression tests asserting the UTF-8 charset attribute is present in the generated scripts).
- Test drafts cleaned up; nothing left in the mailbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)