### PR TITLE
fix: report create_rich_email_draft save_as_draft honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `create_rich_email_draft`'s `save_as_draft` no longer claims or silently
+  retries a save that can never succeed. Mail opens a `.eml` as a read-only
+  message viewer, not a compose object, so the AppleScript `every outgoing
+  message whose subject is ...` query can never match it — the old retry
+  loop always returned `False` after ~5s of polling (#83). The tool now
+  skips the futile retry and reports plainly that `save_as_draft` isn't
+  supported for this workflow, pointing to `compose_email(mode="draft")` or
+  `manage_drafts` for a real, sendable HTML draft.
+
 ## [3.2.0] - 2026-07-04
 
 ### Added

--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import tempfile
 import re
-import time
 from email.message import EmailMessage
 from html import escape as html_escape
 from pathlib import Path
@@ -233,35 +232,11 @@ def _prepare_rich_bodies(subject, text_body, html_body):
     return plain_body, rich_body, []
 
 
-def _save_open_message_as_draft(subject, retries=10, delay_seconds=0.5):
-    """Ask Mail to save the matching open outgoing message as a draft."""
-    if not subject:
-        return False
-
-    safe_subject = escape_applescript(subject)
-    script = f'''
-    tell application "Mail"
-        try
-            set matchingMessages to every outgoing message whose subject is "{safe_subject}"
-            if (count of matchingMessages) is 0 then
-                return "not-found"
-            end if
-            save item 1 of matchingMessages
-            return "saved"
-        on error errMsg
-            return "error: " & errMsg
-        end try
-    end tell
-    '''
-
-    for _ in range(retries):
-        result = run_applescript(script).strip().lower()
-        if result == "saved":
-            return True
-        if result.startswith("error:"):
-            break
-        time.sleep(delay_seconds)
-    return False
+_SAVE_AS_DRAFT_UNSUPPORTED_NOTE = (
+    "save_as_draft could not be honored: Mail opens a `.eml` file as a read-only message "
+    "viewer, not a compose object, so there is no draft for Mail to save here. Use "
+    "compose_email(mode=\"draft\") or manage_drafts for a real, sendable HTML draft instead."
+)
 
 
 @mcp.tool()
@@ -295,7 +270,10 @@ def create_rich_email_draft(
         bcc: Optional BCC recipients, comma-separated for multiple
         output_path: Optional path for the generated `.eml` file
         open_in_mail: If True, open the generated `.eml` in Mail (default: True)
-        save_as_draft: If True, ask Mail to save the opened compose window into Drafts (default: False)
+        save_as_draft: Not currently supported. Mail opens a `.eml` as a read-only message
+            viewer, not a compose object, so it can never be saved into Drafts this way.
+            Passing True is reported honestly in the output rather than silently ignored;
+            use `compose_email(mode="draft")` or `manage_drafts` for a real, sendable draft.
         from_address: Optional sender address to stamp into the `.eml` `From:` header. Must be one of the account's configured email addresses. When omitted, Mail fills the account's default "Send new messages from" address on open.
 
     Returns:
@@ -351,12 +329,10 @@ def create_rich_email_draft(
     draft_path.write_bytes(bytes(message))
 
     opened = False
-    saved = False
+    save_requested = open_in_mail and save_as_draft
     if open_in_mail:
         subprocess.run(["open", "-a", "Mail", str(draft_path)], check=True)
         opened = True
-        if save_as_draft:
-            saved = _save_open_message_as_draft(subject)
 
     output_lines = ["RICH EMAIL DRAFT", "", "✓ Rich draft prepared successfully!", ""]
     output_lines.append("Account: " + account)
@@ -364,7 +340,9 @@ def create_rich_email_draft(
     output_lines.append("EML path: " + str(draft_path))
     output_lines.append("Opened in Mail: " + ("yes" if opened else "no"))
     if open_in_mail:
-        output_lines.append("Saved in Drafts: " + ("yes" if saved else "no"))
+        output_lines.append("Saved in Drafts: no")
+        if save_requested:
+            output_lines.append("Note: " + _SAVE_AS_DRAFT_UNSUPPORTED_NOTE)
     if sender_address:
         output_lines.append("From: " + sender_address)
     if recipients_to:

--- a/tests/test_compose_tools.py
+++ b/tests/test_compose_tools.py
@@ -70,18 +70,17 @@ class ComposeToolTests(unittest.TestCase):
             self.assertIn("Missing details: subject, to, body", result)
             self.assertIn("Opened in Mail: no", result)
 
-    def test_create_rich_email_draft_can_save_to_drafts(self):
+    def test_create_rich_email_draft_reports_save_as_draft_honestly(self):
+        # An opened `.eml` is a read-only Mail viewer, not a compose object, so
+        # save_as_draft can never actually succeed (#83) — the tool must say so
+        # plainly instead of implying the draft was saved.
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "saved.eml"
-            run_results = ["sender@example.com", "saved"]
-
-            def fake_run_applescript(script, timeout=120):
-                return run_results.pop(0)
 
             with (
                 patch(
                     "apple_mail_mcp.tools.compose.run_applescript",
-                    side_effect=fake_run_applescript,
+                    return_value="sender@example.com",
                 ),
                 patch("apple_mail_mcp.tools.compose.subprocess.run"),
             ):
@@ -93,7 +92,29 @@ class ComposeToolTests(unittest.TestCase):
                     save_as_draft=True,
                 )
 
-            self.assertIn("Saved in Drafts: yes", result)
+            self.assertIn("Saved in Drafts: no", result)
+            self.assertIn("save_as_draft could not be honored", result)
+
+    def test_create_rich_email_draft_omits_save_note_when_not_requested(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "unsaved.eml"
+
+            with (
+                patch(
+                    "apple_mail_mcp.tools.compose.run_applescript",
+                    return_value="sender@example.com",
+                ),
+                patch("apple_mail_mcp.tools.compose.subprocess.run"),
+            ):
+                result = compose_tools.create_rich_email_draft(
+                    account="Work",
+                    subject="Unsaved Draft",
+                    output_path=str(output_path),
+                    open_in_mail=True,
+                )
+
+            self.assertIn("Saved in Drafts: no", result)
+            self.assertNotIn("save_as_draft could not be honored", result)
 
 
 class StripCdataTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #83

## Summary
- `save_as_draft` on `create_rich_email_draft` could never actually succeed: Mail opens a `.eml` via `open -a Mail` as a read-only message viewer, not a compose object, so the AppleScript `every outgoing message whose subject is ...` query used to find-and-save it can never match. The old retry loop always returned `False` after ~5s of polling.
- The surrounding "✓ Rich draft prepared successfully!" banner made the "Saved in Drafts: no" line two lines below easy to miss — this is a scoped-down version of the deeper fix proposed in #83 (routing through the working `compose_email`/paste-as-RTF path, or IMAP APPEND), tackling the immediate, low-risk part: don't claim or silently retry something that structurally cannot work.
- Removed the dead `_save_open_message_as_draft` helper (and the now-unused `time` import) and replaced it with a plain, honest note pointing to `compose_email(mode="draft")` / `manage_drafts` for a real, sendable HTML draft.

A full fix that actually makes `save_as_draft` work (option 1 or 2 in #83) is a larger change needing live Mail.app verification (Accessibility permissions, IMAP special-use folder discovery) and is better scoped as its own follow-up.

## Test plan
- [x] Updated `test_create_rich_email_draft_can_save_to_drafts` (which asserted the old, unreachable-in-practice "yes" path) into two tests: one confirming the honest note appears when `save_as_draft=True`, one confirming it's absent when not requested.
- [x] `python -m pytest tests/` — 120 passed
- [x] `python scripts/check_versions.py` — OK