### PR TITLE
fix: bound the get_awaiting_reply inbox scan so large mailboxes stop timing out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,29 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_awaiting_reply` no longer times out on large mailboxes. Its inbox
   cross-reference loop had no date cutoff, no count cap and no early exit, so
   it fetched `subject` and `sender` for *every* message in the inbox — about
-  18,000 AppleEvent round-trips on a 9,000-message account, which exceeded the
-  timeout before the tool returned anything. Accounts with small inboxes were
+  18,000 AppleEvent round-trips on a 9,000-message account, which exceeded
+  the timeout before the tool returned anything (#90). Small inboxes were
   unaffected, so the failure looked account-specific. The inbox scan is now
   bounded to the same date window as the sent scan, following the idiom
-  `get_needs_response` already used, with a hard count cap (`INBOX_SCAN_CAP`)
-  as a backstop for the `days_back=0` all-time path. Measured on the mailbox
-  that surfaced this: timing out before, ~16s after.
-  - The cutoff exit requires a short run of consecutive out-of-window messages
-    (`INBOX_STALE_RUN_LIMIT`) rather than exiting on the first one, so the
-    scan is not silently truncated into "everything is awaiting reply" should
-    Mail's newest-first ordering ever fail to hold.
-  - When the count cap is reached the output says so, rather than silently
-    narrowing the cross-reference.
-  - The reply-matching loop now tests the sender before indexing into
-    `inboxSubjects`. Same conjunction, but the selective test gates the
-    `item idx of` list access, which is O(idx) in AppleScript.
-  - Note one behaviour change: the matcher places no ordering constraint
-    between a sent message and the inbox message it matches, and both sides
-    are prefix-stripped, so a thread *opener* older than the window used to
-    satisfy the match. A sent `Re: Budget` was suppressed by the
-    correspondent's original `Budget` from 30 days earlier even where they
-    never replied. Those are now reported. The reported set only grows, never
-    shrinks.
+  `get_needs_response` already used, with a count cap (`INBOX_SCAN_CAP`) that
+  bounds both paths and is the only bound when `days_back=0`; reaching it is
+  disclosed in the output rather than silently narrowing the cross-reference.
+  The cutoff exit requires a run of consecutive out-of-window messages
+  (`INBOX_STALE_RUN_LIMIT`) rather than exiting on the first, so the scan
+  cannot be silently truncated into "everything is awaiting reply" should
+  Mail's newest-first ordering ever fail to hold. Measured on the mailbox
+  that surfaced this: timing out before, ~16s after. One behaviour change:
+  the matcher places no ordering constraint between a sent message and the
+  inbox message it matches, so a thread *opener* older than the window used
+  to suppress a sent reply to it; those are now reported. The qualifying set
+  only grows, never shrinks, though the returned list stays capped at
+  `max_results`.
 - Removed the redundant `plugin/commands/email-management.md` slash command.
   It shadowed `plugin/skills/email-management/` under the same
   `apple-mail:email-management` listing key, so every session showed two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `get_awaiting_reply` no longer times out on large mailboxes. Its inbox
+  cross-reference loop had no date cutoff, no count cap and no early exit, so
+  it fetched `subject` and `sender` for *every* message in the inbox — about
+  18,000 AppleEvent round-trips on a 9,000-message account, which exceeded the
+  timeout before the tool returned anything. Accounts with small inboxes were
+  unaffected, so the failure looked account-specific. The inbox scan is now
+  bounded to the same date window as the sent scan, following the idiom
+  `get_needs_response` already used, with a hard count cap (`INBOX_SCAN_CAP`)
+  as a backstop for the `days_back=0` all-time path. Measured on the mailbox
+  that surfaced this: timing out before, ~16s after.
+  - The cutoff exit requires a short run of consecutive out-of-window messages
+    (`INBOX_STALE_RUN_LIMIT`) rather than exiting on the first one, so the
+    scan is not silently truncated into "everything is awaiting reply" should
+    Mail's newest-first ordering ever fail to hold.
+  - When the count cap is reached the output says so, rather than silently
+    narrowing the cross-reference.
+  - The reply-matching loop now tests the sender before indexing into
+    `inboxSubjects`. Same conjunction, but the selective test gates the
+    `item idx of` list access, which is O(idx) in AppleScript.
+  - Note one behaviour change: the matcher places no ordering constraint
+    between a sent message and the inbox message it matches, and both sides
+    are prefix-stripped, so a thread *opener* older than the window used to
+    satisfy the match. A sent `Re: Budget` was suppressed by the
+    correspondent's original `Budget` from 30 days earlier even where they
+    never replied. Those are now reported. The reported set only grows, never
+    shrinks.
 - Removed the redundant `plugin/commands/email-management.md` slash command.
   It shadowed `plugin/skills/email-management/` under the same
   `apple-mail:email-management` listing key, so every session showed two

--- a/plugin/apple_mail_mcp/tools/smart_inbox.py
+++ b/plugin/apple_mail_mcp/tools/smart_inbox.py
@@ -25,6 +25,31 @@ _FLAG_COLOR_NAME_LIST = ", ".join(
     f'"{FLAG_COLOR_NAMES[i]}"' for i in sorted(FLAG_COLOR_NAMES)
 )
 
+# --- Bounds for the get_awaiting_reply inbox cross-reference scan ----------
+# Hard ceiling on how many inbox messages are walked. This bounds *cost*, not
+# correctness: it is the backstop for the days_back=0 (all-time) path and for
+# pathological mailboxes. Deliberately generous — a busy fortnight must not be
+# silently truncated, because a truncated cross-reference produces false
+# "awaiting reply" entries. Measured reference: a 9k-message Gmail inbox holds
+# ~410 messages in a 14-day window, and walking 1200 costs ~12s.
+INBOX_SCAN_CAP = 2000
+
+# Mail returns messages newest-first, so the first message older than the
+# cutoff normally means the rest are too. Exiting on the *first* old message
+# would silently truncate the whole scan if that ordering ever failed to hold
+# (yielding "everything is awaiting reply"), so require a short consecutive
+# run before believing we are past the window.
+INBOX_STALE_RUN_LIMIT = 10
+
+# Fetch subject+sender for in-window inbox messages only; out-of-window ones
+# cost a single `date received` round-trip and are skipped.
+_INBOX_COLLECT_PROPS = """                        set msgSubject to subject of aMessage
+                        set msgSender to sender of aMessage
+                        set baseSubject to my stripPrefixes(msgSubject)
+                        set lowerBase to my lowercase(baseSubject)
+                        set end of inboxSubjects to lowerBase
+                        set end of inboxSenders to my lowercase(msgSender)"""
+
 
 def _strip_subject_prefixes_script() -> str:
     """Return AppleScript handler to strip Re:/Fwd:/etc prefixes from a subject."""
@@ -93,6 +118,29 @@ def get_awaiting_reply(
     """
     escaped_account = escape_applescript(account)
 
+    # Body of the inbox-collection loop. A reply to a message sent within
+    # `days_back` must itself have arrived within `days_back`, so bounding the
+    # inbox scan to the same window loses nothing semantically. Unbounded, this
+    # loop fetched two properties for EVERY inbox message (~9k on a long-lived
+    # Gmail account => ~18k AppleEvent round-trips) and the tool timed out
+    # before returning anything. `get_needs_response` below uses the same
+    # bounded-scan idiom.
+    if days_back > 0:
+        inbox_collect_body = f"""
+                    set msgDate to date received of aMessage
+                    if msgDate < cutoffDate then
+                        set staleRun to staleRun + 1
+                        if staleRun > {INBOX_STALE_RUN_LIMIT} then exit repeat
+                    else
+                        set staleRun to 0
+{_INBOX_COLLECT_PROPS}
+                    end if"""
+    else:
+        # days_back=0 means "all time": no cutoff variable exists, so the
+        # count cap is the only bound. (Indentation here is cosmetic.)
+        inbox_collect_body = f"""
+{_INBOX_COLLECT_PROPS}"""
+
     noreply_filter = ""
     if exclude_noreply:
         noreply_filter = '''
@@ -132,19 +180,23 @@ def get_awaiting_reply(
             -- Get Inbox mailbox
             {inbox_mailbox_script("inboxMailbox", "targetAccount")}
 
-            -- Collect subjects from inbox for matching
+            -- Collect subjects from inbox for matching (bounded scan)
             set inboxSubjects to {{}}
             set inboxSenders to {{}}
             set inboxMessages to every message of inboxMailbox
+            set inboxScanned to 0
+            set staleRun to 0
+            set inboxCapHit to false
 
             repeat with aMessage in inboxMessages
+                set inboxScanned to inboxScanned + 1
+                if inboxScanned > {INBOX_SCAN_CAP} then
+                    set inboxCapHit to true
+                    exit repeat
+                end if
+
                 try
-                    set msgSubject to subject of aMessage
-                    set msgSender to sender of aMessage
-                    set baseSubject to my stripPrefixes(msgSubject)
-                    set lowerBase to my lowercase(baseSubject)
-                    set end of inboxSubjects to lowerBase
-                    set end of inboxSenders to my lowercase(msgSender)
+                    {inbox_collect_body}
                 end try
             end repeat
 
@@ -179,13 +231,16 @@ def get_awaiting_reply(
                             set lowerBase to my lowercase(baseSubject)
                             set lowerRecipAddr to my lowercase(recipAddr)
 
-                            -- Check if there is a reply in inbox from this recipient about this subject
+                            -- Check if there is a reply in inbox from this recipient about this subject.
+                            -- Sender is the more selective of the two tests, so it
+                            -- gates the O(idx) indexing into inboxSubjects. Same
+                            -- conjunction as before, just the cheaper order.
                             set foundReply to false
                             set idx to 1
-                            repeat with inboxSubj in inboxSubjects
-                                if inboxSubj contains lowerBase or lowerBase contains inboxSubj then
-                                    set inboxSender to item idx of inboxSenders
-                                    if inboxSender contains lowerRecipAddr then
+                            repeat with inboxSender in inboxSenders
+                                if inboxSender contains lowerRecipAddr then
+                                    set inboxSubj to item idx of inboxSubjects
+                                    if inboxSubj contains lowerBase or lowerBase contains inboxSubj then
                                         set foundReply to true
                                         exit repeat
                                     end if
@@ -210,6 +265,9 @@ def get_awaiting_reply(
 
             set outputText to outputText & "========================================" & return
             set outputText to outputText & "Found " & resultCount & " sent email(s) awaiting reply." & return
+            if inboxCapHit then
+                set outputText to outputText & "NOTE: inbox scan stopped at {INBOX_SCAN_CAP} messages; older inbox mail was not cross-referenced, so some entries above may already have replies." & return
+            end if
 
         on error errMsg
             return "Error: " & errMsg

--- a/plugin/apple_mail_mcp/tools/smart_inbox.py
+++ b/plugin/apple_mail_mcp/tools/smart_inbox.py
@@ -27,12 +27,19 @@ _FLAG_COLOR_NAME_LIST = ", ".join(
 
 # --- Bounds for the get_awaiting_reply inbox cross-reference scan ----------
 # Hard ceiling on how many inbox messages are walked. This bounds *cost*, not
-# correctness: it is the backstop for the days_back=0 (all-time) path and for
-# pathological mailboxes. Deliberately generous — a busy fortnight must not be
-# silently truncated, because a truncated cross-reference produces false
-# "awaiting reply" entries. Measured reference: a 9k-message Gmail inbox holds
-# ~410 messages in a 14-day window, and walking 1200 costs ~12s.
-INBOX_SCAN_CAP = 2000
+# correctness, and it is sized to fit the run_applescript default timeout
+# (120s): an in-window message costs ~3 Mail round-trips plus 2 `lowercase`
+# shell calls, ~45-50ms, so a saturated scan is ~45-50s and leaves headroom for
+# the sent scan that follows. Measured reference: a 9k-message Gmail inbox
+# holds ~410 messages in a 14-day window (walking 1200 costs ~12s), so this is
+# ~2.4x the real fortnightly volume. Truncation is disclosed in the output
+# rather than silently narrowing the cross-reference, because a silently
+# truncated cross-reference yields false "awaiting reply" entries.
+#
+# Note this caps the *inbox* side only. On days_back=0 the sent loop below has
+# no date cutoff either and is bounded only by max_results; that is
+# pre-existing and not addressed here.
+INBOX_SCAN_CAP = 1000
 
 # Mail returns messages newest-first, so the first message older than the
 # cutoff normally means the rest are too. Exiting on the *first* old message
@@ -43,12 +50,21 @@ INBOX_STALE_RUN_LIMIT = 10
 
 # Fetch subject+sender for in-window inbox messages only; out-of-window ones
 # cost a single `date received` round-trip and are skipped.
+#
+# inboxSubjects and inboxSenders are parallel lists indexed in lockstep by the
+# matching loop, so every operation that can throw runs BEFORE either append.
+# Appending the subject and then throwing on the sender would shift every
+# later index by one, silently pairing each subject with the next message's
+# sender — which loses genuine reply matches and reports answered mail as
+# awaiting reply. (`lowercase` throws on `missing value`, so this is reachable
+# whenever Mail returns a message with no sender.)
 _INBOX_COLLECT_PROPS = """                        set msgSubject to subject of aMessage
                         set msgSender to sender of aMessage
                         set baseSubject to my stripPrefixes(msgSubject)
                         set lowerBase to my lowercase(baseSubject)
+                        set lowerSender to my lowercase(msgSender)
                         set end of inboxSubjects to lowerBase
-                        set end of inboxSenders to my lowercase(msgSender)"""
+                        set end of inboxSenders to lowerSender"""
 
 
 def _strip_subject_prefixes_script() -> str:
@@ -109,7 +125,7 @@ def get_awaiting_reply(
 
     Args:
         account: Account name (e.g., "Gmail", "Work", "Personal")
-        days_back: How many days back to check sent emails (default: 7)
+        days_back: How many days back to check sent emails (default: 7, 0 = all time)
         exclude_noreply: Skip emails sent to noreply/no-reply addresses (default: True)
         max_results: Maximum results to return (default: 20)
 
@@ -203,7 +219,6 @@ def get_awaiting_reply(
             -- Now scan sent emails
             set sentMessages to every message of sentMailbox
             set resultCount to 0
-            set checkedCount to 0
 
             repeat with aMessage in sentMessages
                 if resultCount >= {max_results} then exit repeat

--- a/plugin/apple_mail_mcp/tools/smart_inbox.py
+++ b/plugin/apple_mail_mcp/tools/smart_inbox.py
@@ -134,13 +134,23 @@ def get_awaiting_reply(
     """
     escaped_account = escape_applescript(account)
 
-    # Body of the inbox-collection loop. A reply to a message sent within
-    # `days_back` must itself have arrived within `days_back`, so bounding the
-    # inbox scan to the same window loses nothing semantically. Unbounded, this
-    # loop fetched two properties for EVERY inbox message (~9k on a long-lived
-    # Gmail account => ~18k AppleEvent round-trips) and the tool timed out
-    # before returning anything. `get_needs_response` below uses the same
-    # bounded-scan idiom.
+    # Body of the inbox-collection loop. Unbounded, this loop fetched two
+    # properties for EVERY inbox message (~9k on a long-lived Gmail account
+    # => ~18k AppleEvent round-trips) and the tool timed out before returning
+    # anything. `get_needs_response` below uses the same bounded-scan idiom.
+    #
+    # Bounding the inbox to the same window as the sent scan never hides a
+    # genuine reply: a reply to something sent within `days_back` must itself
+    # have arrived within `days_back`. It does change one case. The matcher
+    # below places no ordering constraint between the sent message and the
+    # inbox message it matches, and both sides are prefix-stripped, so a
+    # thread OPENER older than the window used to satisfy the match as well —
+    # a sent "Re: Budget" was suppressed by the correspondent's original
+    # "Budget" from 30 days ago, even where they never actually replied.
+    # Those sent messages are now reported. The change is one-directional
+    # (the reported set only grows, never shrinks) and the new entries are
+    # true positives for the question this tool asks: she sent last, so the
+    # reply is owed to her.
     if days_back > 0:
         inbox_collect_body = f"""
                     set msgDate to date received of aMessage
@@ -151,11 +161,13 @@ def get_awaiting_reply(
                         set staleRun to 0
 {_INBOX_COLLECT_PROPS}
                     end if"""
+        stale_run_init = "\n            set staleRun to 0"
     else:
         # days_back=0 means "all time": no cutoff variable exists, so the
         # count cap is the only bound. (Indentation here is cosmetic.)
         inbox_collect_body = f"""
 {_INBOX_COLLECT_PROPS}"""
+        stale_run_init = ""
 
     noreply_filter = ""
     if exclude_noreply:
@@ -200,8 +212,7 @@ def get_awaiting_reply(
             set inboxSubjects to {{}}
             set inboxSenders to {{}}
             set inboxMessages to every message of inboxMailbox
-            set inboxScanned to 0
-            set staleRun to 0
+            set inboxScanned to 0{stale_run_init}
             set inboxCapHit to false
 
             repeat with aMessage in inboxMessages

--- a/plugin/apple_mail_mcp/tools/smart_inbox.py
+++ b/plugin/apple_mail_mcp/tools/smart_inbox.py
@@ -147,10 +147,11 @@ def get_awaiting_reply(
     # thread OPENER older than the window used to satisfy the match as well —
     # a sent "Re: Budget" was suppressed by the correspondent's original
     # "Budget" from 30 days ago, even where they never actually replied.
-    # Those sent messages are now reported. The change is one-directional
-    # (the reported set only grows, never shrinks) and the new entries are
-    # true positives for the question this tool asks: she sent last, so the
-    # reply is owed to her.
+    # Those sent messages are now reported. The set of QUALIFYING messages
+    # only grows, never shrinks — but the returned list is still capped at
+    # max_results, so a newly-unsuppressed message can push a previously
+    # returned one past the cap. The new entries are true positives for the
+    # question this tool asks: you sent last, so the reply is owed to you.
     if days_back > 0:
         inbox_collect_body = f"""
                     set msgDate to date received of aMessage

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -503,6 +503,69 @@ class SmartInboxToolTests(unittest.TestCase):
         )
         self.assertIn('"HIGH (" & flagLabel & " + question)"', captured["script"])
 
+    @staticmethod
+    def _awaiting_reply_script(**kwargs):
+        captured = {}
+
+        def fake_run(script, timeout=120):
+            captured["script"] = script
+            return "no results"
+
+        with patch(
+            "apple_mail_mcp.tools.smart_inbox.run_applescript", side_effect=fake_run
+        ):
+            smart_inbox_tools.get_awaiting_reply(account="Work", **kwargs)
+
+        return captured["script"]
+
+    def test_get_awaiting_reply_bounds_inbox_scan_by_date(self):
+        """The inbox cross-reference must stop at the date cutoff.
+
+        Unbounded, this loop fetched two properties for every message in the
+        inbox, which timed out on large mailboxes before returning anything.
+        """
+        script = self._awaiting_reply_script(days_back=14)
+
+        # date received is fetched first so out-of-window messages cost one
+        # round-trip instead of three.
+        self.assertIn("set msgDate to date received of aMessage", script)
+        self.assertIn("if msgDate < cutoffDate then", script)
+        self.assertIn(
+            f"if staleRun > {smart_inbox_tools.INBOX_STALE_RUN_LIMIT} then exit repeat",
+            script,
+        )
+        # Subject/sender are only fetched for in-window messages.
+        self.assertIn("set end of inboxSubjects to lowerBase", script)
+
+    def test_get_awaiting_reply_caps_inbox_scan_count(self):
+        """A hard count cap bounds cost independently of the date cutoff."""
+        for days_back in (14, 0):
+            with self.subTest(days_back=days_back):
+                script = self._awaiting_reply_script(days_back=days_back)
+                self.assertIn("set inboxScanned to inboxScanned + 1", script)
+                self.assertIn(
+                    f"if inboxScanned > {smart_inbox_tools.INBOX_SCAN_CAP} then", script
+                )
+                # Truncation is disclosed rather than silently changing results.
+                self.assertIn("if inboxCapHit then", script)
+
+    def test_get_awaiting_reply_all_time_has_no_cutoff_reference(self):
+        """days_back=0 means all time: cutoffDate is never defined, so the
+        generated script must not reference it (the count cap is the bound)."""
+        script = self._awaiting_reply_script(days_back=0)
+
+        self.assertNotIn("cutoffDate", script)
+        self.assertIn("set inboxScanned to inboxScanned + 1", script)
+
+    def test_get_awaiting_reply_matches_on_sender_before_indexing_subjects(self):
+        """Sender is the selective test, so it gates the O(idx) list indexing."""
+        script = self._awaiting_reply_script(days_back=14)
+
+        self.assertIn("repeat with inboxSender in inboxSenders", script)
+        sender_check = script.index("if inboxSender contains lowerRecipAddr then")
+        subject_index = script.index("set inboxSubj to item idx of inboxSubjects")
+        self.assertLess(sender_check, subject_index)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mail_search_tools.py
+++ b/tests/test_mail_search_tools.py
@@ -526,9 +526,6 @@ class SmartInboxToolTests(unittest.TestCase):
         """
         script = self._awaiting_reply_script(days_back=14)
 
-        # date received is fetched first so out-of-window messages cost one
-        # round-trip instead of three.
-        self.assertIn("set msgDate to date received of aMessage", script)
         self.assertIn("if msgDate < cutoffDate then", script)
         self.assertIn(
             f"if staleRun > {smart_inbox_tools.INBOX_STALE_RUN_LIMIT} then exit repeat",
@@ -536,6 +533,46 @@ class SmartInboxToolTests(unittest.TestCase):
         )
         # Subject/sender are only fetched for in-window messages.
         self.assertIn("set end of inboxSubjects to lowerBase", script)
+
+        # `date received` must be fetched BEFORE subject/sender, so an
+        # out-of-window message costs one round-trip instead of three. That
+        # cost property is the whole point of the fix, so pin the order.
+        date_fetch = script.index("set msgDate to date received of aMessage")
+        subject_fetch = script.index("set msgSubject to subject of aMessage")
+        self.assertLess(date_fetch, subject_fetch)
+
+    def test_get_awaiting_reply_stale_run_counts_consecutive_only(self):
+        """The stale-run counter must reset on every in-window message.
+
+        Without the reset it becomes a cumulative count, and a mailbox with
+        INBOX_STALE_RUN_LIMIT out-of-window messages scattered anywhere in the
+        scan would truncate the entire cross-reference — reporting answered
+        mail as awaiting reply, the exact failure the tolerance exists to
+        prevent.
+        """
+        script = self._awaiting_reply_script(days_back=14)
+
+        self.assertIn("set staleRun to staleRun + 1", script)
+        # The reset lives in the else branch, i.e. after the increment.
+        increment = script.index("set staleRun to staleRun + 1")
+        reset = script.index("set staleRun to 0", increment)
+        self.assertGreater(reset, increment)
+        # ...and before the in-window property fetch it guards.
+        self.assertLess(reset, script.index("set msgSubject to subject of aMessage"))
+
+    def test_get_awaiting_reply_keeps_parallel_lists_index_aligned(self):
+        """Both appends must follow every operation that can throw.
+
+        inboxSubjects and inboxSenders are indexed in lockstep by the matching
+        loop. Appending a subject and then throwing on the sender would shift
+        every later index by one and silently mispair subjects with senders.
+        """
+        script = self._awaiting_reply_script(days_back=14)
+
+        last_throwing = script.index("set lowerSender to my lowercase(msgSender)")
+        first_append = script.index("set end of inboxSubjects to lowerBase")
+        self.assertLess(last_throwing, first_append)
+        self.assertIn("set end of inboxSenders to lowerSender", script)
 
     def test_get_awaiting_reply_caps_inbox_scan_count(self):
         """A hard count cap bounds cost independently of the date cutoff."""


### PR DESCRIPTION
## The problem

`get_awaiting_reply` reliably timed out on one of my accounts and worked fine on four others. The account that failed has ~9,000 messages in its INBOX; the others are small.

The cause is the inbox cross-reference loop, which had no date cutoff, no count cap and no early exit:

```applescript
set inboxMessages to every message of inboxMailbox
repeat with aMessage in inboxMessages
    set msgSubject to subject of aMessage
    set msgSender to sender of aMessage
    ...
end repeat
```

Two properties for every message in the mailbox — roughly 18,000 AppleEvent round-trips at ~10ms each, plus the `do shell script` spawn that `lowercase` makes per sender. It never got as far as scanning Sent. Raising the timeout only makes the caller hang longer, which is what sent me looking at the loop.

`get_needs_response`, in the same file, does not have this problem because its scans are already bounded (`if sentIdx > 200 then exit repeat`, plus a cutoff exit on the main loop). This PR applies that existing idiom to `get_awaiting_reply`.

## The change

A reply to a message sent within `days_back` must itself have arrived within `days_back`, so the inbox scan is bounded to the same window as the sent scan. `date received` is fetched first, so an out-of-window message costs one round-trip instead of three.

Three details worth review:

1. **The cutoff exit needs a tolerance.** Exiting on the *first* out-of-window message would silently truncate the entire cross-reference if Mail's newest-first ordering ever failed to hold — and a truncated cross-reference means "nothing matched", i.e. every sent message reported as awaiting reply. It now requires `INBOX_STALE_RUN_LIMIT` consecutive out-of-window messages. I verified the ordering assumption rather than assuming it: zero date inversions across the first 1,200 messages, with 410 in a 14-day window.

2. **`INBOX_SCAN_CAP` is a cost bound, not a correctness bound.** The counter sits above the `days_back` branch, so it bounds both paths, and it is the only bound when `days_back=0`. It is sized to fit the `run_applescript` default timeout, and when it fires the output says so rather than silently narrowing the cross-reference. (It bounds the inbox side only; the sent loop is also unbounded on `days_back=0`, which is pre-existing and not touched here.)

3. **One behaviour change, in the reporting-more direction.** The matcher places no ordering constraint between the sent message and the inbox message it matches, and both sides are prefix-stripped, so a thread *opener* older than the window used to satisfy the match too: a sent `Re: Budget` was suppressed by the correspondent's original `Budget` from 30 days earlier, even where they never replied. Those sent messages are now reported. The set of *qualifying* messages only grows, never shrinks — though the returned list is still capped at `max_results`, so on a busy account a newly-unsuppressed message can push a previously-returned one past the cap. I left the matcher alone deliberately — adding a date guard there is a semantic change, not part of a timeout fix — but I am happy to follow up if you would rather it required the match to be newer.

Also swaps the two conditions in the matching loop so the selective sender test gates the `item idx of inboxSubjects` access, which is O(idx) in AppleScript.

## Verification

- The account that used to time out: **~16s**, well inside the timeout.
- **Output is byte-identical to the previous implementation across 8 account/window combinations** (4 accounts × `days_back` ∈ {14, 60}) — everything where the old code still completed. The baseline was re-captured immediately before comparison, because mail arriving mid-test otherwise shows up as a false diff.
- Spot-checked against ground truth: on one account the 14-day sent window contains exactly 1 message and the tool reports exactly that 1. On another, a 60-day window holds 27 sent messages and 7 are reported; the remaining 20 are all threads with two-way correspondence.
- Generated AppleScript compiles under `osacompile` for `days_back` ∈ {14, 7, 60, 0, -5}.
- 6 new unit tests in the existing style (assert on the generated script), pinning the cutoff exit, the count cap, the absence of any `cutoffDate` reference on the all-time path, the stale-run *reset* (the line that makes the counter consecutive rather than cumulative), the `date received`-first fetch order, and the append ordering that keeps `inboxSubjects`/`inboxSenders` index-aligned.
- CI's own commands run clean locally: `scripts/check_versions.py` passes, and `pytest tests/ -q` on 3.12 gives 126 passed. (The workflow itself is held at `action_required` pending maintainer approval, as it is for any first-time fork contributor.)

Related to #41 in kind — unbounded scan over a large INBOX — though that one is `search_emails`, a different tool, so this does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
