### PR TITLE
Fix reply drafts rendering in serif/small font

### DIFF
--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -153,7 +153,9 @@ def _build_html_from_text(text_body):
     return (
         '<html><body style="font-family: -apple-system, BlinkMacSystemFont, '
         "'Segoe UI', Arial, sans-serif; line-height: 1.45; color: #111111;\">"
-        '<pre style="white-space: pre-wrap; font: inherit; margin: 0;">'
+        '<pre style="white-space: pre-wrap; margin: 0; font-family: '
+        "-apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; "
+        'font-size: 13px;">'
         + safe_body
         + "</pre></body></html>"
     )

--- a/plugin/apple_mail_mcp/tools/compose.py
+++ b/plugin/apple_mail_mcp/tools/compose.py
@@ -17,6 +17,18 @@ from apple_mail_mcp.core import (
     inbox_mailbox_script,
 )
 
+# Explicit font stack for HTML fragments that get pasted into Mail's compose
+# editor via NSPasteboard. Cocoa's HTML->NSAttributedString importer does not
+# resolve CSS shorthand like `font: inherit`, and a fragment with no
+# font-family at all resolves even worse (falls back to Times-Roman). Every
+# fragment needs a concrete font-family value or it silently renders in a
+# small serif font instead of the sans-serif Mail normally composes in.
+# See #100.
+_COMPOSE_FONT_STYLE = (
+    "font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, "
+    "sans-serif; font-size: 13px;"
+)
+
 
 def _split_addresses(value):
     """Return trimmed recipient addresses preserving order."""
@@ -693,7 +705,9 @@ def reply_to_email(
         # Wrap plain text in HTML, converting newlines to <br>
         escaped_plain = html_escape(reply_body)
         escaped_plain = escaped_plain.replace("\n", "<br>")
-        html_content = f"<div>{escaped_plain}</div>{gap_html}"
+        html_content = (
+            f'<div style="{_COMPOSE_FONT_STYLE}">{escaped_plain}</div>{gap_html}'
+        )
     html_tmp = tempfile.NamedTemporaryFile(
         mode="w",
         suffix=".html",
@@ -1247,7 +1261,9 @@ def forward_email(
     if message:
         escaped_plain = html_escape(message)
         escaped_plain = escaped_plain.replace("\n", "<br>")
-        fwd_html_content = f"{escaped_plain}<br><br>"
+        fwd_html_content = (
+            f'<div style="{_COMPOSE_FONT_STYLE}">{escaped_plain}<br><br></div>'
+        )
         fwd_html_tmp = tempfile.NamedTemporaryFile(
             mode="w",
             suffix=".html",


### PR DESCRIPTION
## Root cause

`_build_html_from_text()` in `plugin/apple_mail_mcp/tools/compose.py` builds the HTML used for reply/compose drafts. The `<body>` element declares a sans-serif `font-family`, and the `<pre>` element wrapping the message text relied on CSS inheritance via `font: inherit` to pick that up.

When this HTML is converted to an `NSAttributedString` for pasting into Mail's compose editor (see `_html_to_pasteboard_script`), Cocoa's HTML importer does not resolve the `font: inherit` shorthand on `<pre>`. Instead of inheriting the sans-serif family from `<body>`, it falls back to a default serif font at a small point size — so reply drafts render in serif/small text instead of the intended sans-serif.

## Fix

Repeat the same font-family list explicitly on the `<pre>` element instead of relying on `font: inherit`, and add an explicit `font-size`, so the importer has a concrete value to resolve rather than an inherited one it fails to compute.

```diff
-        '<pre style="white-space: pre-wrap; font: inherit; margin: 0;">'
+        '<pre style="white-space: pre-wrap; margin: 0; font-family: '
+        "-apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; "
+        'font-size: 13px;">'
```

Fixes #100

https://claude.ai/code/session_01KbACWHEN1azkaPGndZy22c